### PR TITLE
Fix code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/tests/dbtest.py
+++ b/tests/dbtest.py
@@ -75,7 +75,7 @@ def setup_database_test_case():
             print("HEVELIUS_DEBUG is set, not dropping the test database.")
         else:
             drop_database_query = f"DROP DATABASE {test_config['database']};"
-            print(f"HEVELIUS_DEBUG not set, dropping database: {test_config['database']}")
+            print("HEVELIUS_DEBUG not set, dropping the test database.")
             maintenance_cursor.execute(drop_database_query)
 
         maintenance_cursor.close()


### PR DESCRIPTION
Fixes [https://github.com/tomaszmrugalski/hevelius-backend/security/code-scanning/6](https://github.com/tomaszmrugalski/hevelius-backend/security/code-scanning/6)

To fix the problem, we should ensure that no sensitive information is logged. In this case, we should avoid logging the database name, even though it is not directly sensitive, to prevent any potential exposure of sensitive data. We can modify the logging statement to provide a generic message that does not include any specific details from the configuration.

- Replace the logging statement on line 78 with a generic message that does not include the database name.
- Ensure that the new logging statement provides sufficient information for debugging without exposing any sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
