### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Pytest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/borowka-obs/hevelius-backend/security/code-scanning/15](https://github.com/borowka-obs/hevelius-backend/security/code-scanning/15)

To fix the problem, we should add a `permissions` block to either the root of the workflow or to each job that does not have one. In this case, it makes most sense to add `permissions:` at the root level (just below `name: ...` and before `on:`), which will apply least privilege settings to all jobs in this workflow. The minimal starting point usually is `contents: read` unless any job requires more. This ensures the workflow only has enough permission to read the contents of the repository, which suffices for checking out source code, installing dependencies, and running tests. Only modify `.github/workflows/testing.yml` by adding:

```yaml
permissions:
  contents: read
```

just after the workflow `name:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `permissions: contents: read` to the root of `pylint.yml` and `testing.yml` workflows.
> 
> - **CI/GitHub Actions**:
>   - Add `permissions: contents: read` at the workflow root in `.github/workflows/pylint.yml` and `.github/workflows/testing.yml` to enforce least-privilege.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 269b035df82a7deaa568afec4372844bfebe0232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->