### PR TITLE
Faster tests

### DIFF
--- a/db/schema-consolidated.psql
+++ b/db/schema-consolidated.psql
@@ -1,0 +1,286 @@
+-- =============================================================================
+-- CONSOLIDATED SCHEMA FOR TESTING
+-- =============================================================================
+-- This file represents the complete final schema (version 14) and is used
+-- ONLY for faster test execution. For production deployments, always use
+-- the incremental migration files (07-*.psql through 14-*.psql).
+--
+-- DO NOT manually edit this file. Regenerate it using:
+--   python -m hevelius.cmd_db_migrate --generate-consolidated
+-- or manually by applying all incremental migrations to a fresh database
+-- and dumping the schema.
+--
+-- Generated from incremental files: 07-init.psql through 14-catalogs-and-indexes.psql
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- Table: users
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS users (
+  user_id SERIAL,
+  login varchar(32) DEFAULT NULL,
+  pass varchar(32) DEFAULT NULL,
+  firstname varchar(32) DEFAULT NULL,
+  lastname varchar(32) DEFAULT NULL,
+  share float DEFAULT NULL,
+  phone varchar(11) DEFAULT NULL,
+  email varchar(64) DEFAULT NULL,
+  permissions int NOT NULL DEFAULT 0,
+  aavso_id varchar(5) DEFAULT NULL,
+  ftp_login varchar(32) DEFAULT NULL,
+  ftp_pass varchar(32) DEFAULT NULL,
+  pass_d varchar(50) DEFAULT NULL,
+  PRIMARY KEY (user_id)
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: filters
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS filters (
+  scope_id int DEFAULT NULL,
+  filter_id varchar(16) DEFAULT NULL,
+  descr varchar(128) DEFAULT NULL,
+  id SERIAL,
+  PRIMARY KEY (id)
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: sensors (from schema 10)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sensors (
+  sensor_id SERIAL,
+  name varchar(128),
+  resx int,
+  resy int,
+  pixel_x float,
+  pixel_y float,
+  bits smallint,
+  width float,
+  height float,
+  PRIMARY KEY (sensor_id)
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: telescopes (with additions from schema 13)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS telescopes (
+  scope_id int NOT NULL,
+  name varchar(64) DEFAULT NULL,
+  descr varchar(1024) DEFAULT NULL,
+  min_dec float DEFAULT NULL,
+  max_dec float DEFAULT NULL,
+  focal float,
+  aperture float,
+  lon float,
+  lat float,
+  alt float,
+  active boolean DEFAULT true,
+  sensor_id integer,
+  PRIMARY KEY (scope_id),
+  CONSTRAINT scope_id_unique UNIQUE(scope_id),
+  CONSTRAINT fk_sensor FOREIGN KEY(sensor_id) REFERENCES sensors(sensor_id)
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: catalogs (from schema 09)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS catalogs (
+  name varchar UNIQUE,
+  shortname varchar(32) PRIMARY KEY,
+  filename varchar(64),
+  descr text,
+  url text,
+  version varchar(32)
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: objects (with additions from schema 09 and 14)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS objects (
+  object_id SERIAL,
+  name varchar(68) NOT NULL,
+  ra float DEFAULT NULL,
+  decl float DEFAULT NULL,
+  descr varchar(1024) DEFAULT NULL,
+  comment text DEFAULT NULL,
+  type varchar(4) DEFAULT NULL,
+  epoch varchar(7) DEFAULT NULL,
+  const varchar(3) DEFAULT NULL,
+  magn float DEFAULT NULL,
+  x float DEFAULT NULL,
+  y float DEFAULT NULL,
+  altname varchar(128),
+  distance float,
+  catalog varchar(32) NOT NULL,
+  PRIMARY KEY (object_id),
+  FOREIGN KEY (catalog) REFERENCES catalogs(shortname)
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: schema_version
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS schema_version (
+  version int DEFAULT NULL
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: settings
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS settings (
+  settings_id SERIAL,
+  name varchar(50) DEFAULT NULL,
+  value varchar(1024) DEFAULT NULL,
+  comment varchar(100) DEFAULT NULL,
+  PRIMARY KEY (settings_id)
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: task_states (renamed from states in schema 11)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS task_states (
+  id int NOT NULL UNIQUE,
+  name varchar(16) DEFAULT NULL,
+  descr varchar(128) DEFAULT NULL
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: tasks (with modifications from schema 08, 10, 12)
+-- Final schema with boolean types and sensor_id, without vphot/defocus
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tasks (
+  task_id SERIAL,
+  user_id int NOT NULL,
+  scope_id int NOT NULL,
+  object varchar(64) DEFAULT NULL,
+  ra float DEFAULT NULL,
+  decl float DEFAULT NULL,
+  exposure float DEFAULT NULL,
+  descr varchar(1024) DEFAULT NULL,
+  filter varchar(16) DEFAULT NULL,
+  binning smallint DEFAULT NULL,
+  guiding bool DEFAULT True,
+  dither bool DEFAULT False,
+  calibrate bool DEFAULT NULL,
+  solve bool DEFAULT NULL,
+  other_cmd varchar(512) DEFAULT NULL,
+  min_alt float DEFAULT NULL,
+  moon_distance float DEFAULT NULL,
+  skip_before timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
+  skip_after timestamp NOT NULL DEFAULT '3000-01-01 00:00:00',
+  min_interval int DEFAULT NULL,
+  comment text DEFAULT NULL,
+  state int NOT NULL,
+  imagename varchar(256) DEFAULT NULL,
+  created timestamp NOT NULL DEFAULT now(),
+  activated timestamp NULL DEFAULT NULL,
+  performed timestamp NULL DEFAULT NULL,
+  max_moon_phase int DEFAULT NULL,
+  max_sun_alt int DEFAULT NULL,
+  auto_center bool DEFAULT False,
+  calibrated bool DEFAULT False,
+  solved bool DEFAULT False,
+  sent bool DEFAULT False,
+  he_resx int DEFAULT NULL,
+  he_resy int DEFAULT NULL,
+  he_obsstart timestamp DEFAULT NULL,
+  he_exposure float DEFAULT NULL,
+  he_settemp float DEFAULT NULL,
+  he_ccdtemp float DEFAULT NULL,
+  he_pixwidth float DEFAULT NULL,
+  he_pixheight float DEFAULT NULL,
+  he_xbinning int DEFAULT NULL,
+  he_ybinning int DEFAULT NULL,
+  he_filter varchar(20) DEFAULT NULL,
+  he_objectra float DEFAULT NULL,
+  he_objectdec float DEFAULT NULL,
+  he_objectalt float DEFAULT NULL,
+  he_objectaz float DEFAULT NULL,
+  he_objectha float DEFAULT NULL,
+  he_site_lat float DEFAULT NULL,
+  he_site_lon float DEFAULT NULL,
+  he_pierside varchar(4) DEFAULT NULL,
+  he_jd float DEFAULT NULL,
+  he_jd_helio float DEFAULT NULL,
+  he_tracktime float DEFAULT NULL,
+  he_focal float DEFAULT NULL,
+  he_aperture_diam float DEFAULT NULL,
+  he_aperture_area float DEFAULT NULL,
+  he_scope varchar(32) DEFAULT NULL,
+  he_camera varchar(64) DEFAULT NULL,
+  he_moon_alt float DEFAULT NULL,
+  he_moon_angle float DEFAULT NULL,
+  he_moon_phase float DEFAULT NULL,
+  he_sun_alt float DEFAULT NULL,
+  he_solved smallint DEFAULT NULL,
+  he_solved_ra float DEFAULT NULL,
+  he_solved_dec float DEFAULT NULL,
+  he_solved_refx int DEFAULT NULL,
+  he_solved_refy int DEFAULT NULL,
+  he_pixscalex float DEFAULT NULL,
+  he_pixscaley float DEFAULT NULL,
+  he_solved_ra_change_x float DEFAULT NULL,
+  he_solved_ra_change_y float DEFAULT NULL,
+  he_solved_dec_change_x float DEFAULT NULL,
+  he_solved_dec_change_y float DEFAULT NULL,
+  he_fwhm float DEFAULT NULL,
+  he_stars float DEFAULT NULL,
+  eccentricity float DEFAULT NULL,
+  sensor_id integer,
+  PRIMARY KEY (task_id),
+  CONSTRAINT fk_state FOREIGN KEY (state) REFERENCES task_states (id),
+  CONSTRAINT fk_scope FOREIGN KEY (scope_id) REFERENCES telescopes (scope_id),
+  CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
+  CONSTRAINT fk_sensor FOREIGN KEY (sensor_id) REFERENCES sensors (sensor_id)
+);
+
+-- -----------------------------------------------------------------------------
+-- Table: user_preferences
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS user_preferences (
+  pref_id SERIAL,
+  user_id int DEFAULT NULL,
+  exposure int DEFAULT 75,
+  filter varchar(20) DEFAULT 'CV',
+  binning int DEFAULT 2,
+  guiding smallint DEFAULT 1,
+  dither smallint DEFAULT NULL,
+  calibrate smallint DEFAULT 1,
+  solve int DEFAULT 1,
+  min_alt int DEFAULT 35,
+  moon_distance int DEFAULT 0,
+  max_sun_alt int NOT NULL DEFAULT -12,
+  max_moon_phase int DEFAULT NULL,
+  PRIMARY KEY (pref_id),
+  CONSTRAINT fk_user_pref FOREIGN KEY(user_id) REFERENCES users(user_id)
+);
+
+-- -----------------------------------------------------------------------------
+-- Indexes (from schema 14)
+-- -----------------------------------------------------------------------------
+CREATE INDEX ON tasks(task_id);
+
+-- For case-insensitive search on name and altname
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX objects_name_trgm_idx ON objects USING gin (name gin_trgm_ops);
+CREATE INDEX objects_altname_trgm_idx ON objects USING gin (altname gin_trgm_ops);
+
+-- For sorting by name
+CREATE INDEX objects_name_idx ON objects (name);
+
+-- For filtering by catalog
+CREATE INDEX objects_catalog_idx ON objects (catalog);
+
+-- For sorting by different fields
+CREATE INDEX objects_ra_idx ON objects (ra);
+CREATE INDEX objects_decl_idx ON objects (decl);
+
+-- For spatial queries using RA/DEC
+CREATE INDEX objects_ra_decl_idx ON objects (ra, decl);
+
+-- For exact name lookups
+CREATE INDEX objects_name_exact_idx ON objects (name);
+
+-- -----------------------------------------------------------------------------
+-- Set schema version to 14 (current latest)
+-- -----------------------------------------------------------------------------
+INSERT INTO schema_version VALUES (14);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""
+Pytest configuration for Hevelius tests.
+
+This module provides session-scoped fixtures for database setup and cleanup.
+"""
+
+import pytest
+from tests.dbtest import cleanup_template_database
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_after_tests():
+    """Clean up template database after all tests complete."""
+    # Setup: nothing to do, template is created lazily
+    yield
+    # Teardown: clean up the template database
+    cleanup_template_database()

--- a/tests/dbtest.py
+++ b/tests/dbtest.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 from functools import wraps
 from contextlib import contextmanager
 
@@ -11,6 +12,10 @@ from hevelius.cmd_db_migrate import migrate_pgsql, run_file
 # The relative path to the root directory.
 _root_dir = os.path.dirname(os.path.realpath(__file__))
 _root_dir = os.path.dirname(_root_dir)
+
+# Dictionary to track created template databases by their data file
+# Key: hash of load_test_data path (or "none"), Value: template database name
+_template_dbs = {}
 
 
 def _read_configuration():
@@ -37,8 +42,16 @@ def _read_configuration():
     })
 
 
+def _get_template_suffix(load_test_data: str) -> str:
+    '''Generate a short suffix for template database name based on test data file.'''
+    if load_test_data is None:
+        return "nodata"
+    # Use a short hash of the file path to create unique template names
+    return hashlib.md5(load_test_data.encode()).hexdigest()[:8]
+
+
 def _standard_seed_db(config, load_test_data: str):
-    '''Migrate and seed the test database.'''
+    '''Migrate and seed the test database using incremental migrations.'''
     migrate_pgsql({"dry_run": False}, cfg=config)
 
     if load_test_data is not None:
@@ -48,33 +61,152 @@ def _standard_seed_db(config, load_test_data: str):
         print("Skipping loading data.")
 
 
-@contextmanager
-def setup_database_test_case(*, load_test_data: str = None):
-    '''Create the test database, migrate it to the latest version, and
-    destroy after test case.'''
-    mgmt_config, test_config = _read_configuration()
+def _fast_seed_db(config, load_test_data: str):
+    '''Seed the test database using consolidated schema (faster for tests).'''
+    from hevelius import db
+
+    consolidated_schema = os.path.join(_root_dir, "db", "schema-consolidated.psql")
+
+    if not os.path.exists(consolidated_schema):
+        print(f"Consolidated schema not found at {consolidated_schema}, falling back to incremental migrations")
+        _standard_seed_db(config, load_test_data)
+        return
+
+    print(f"Using consolidated schema from {consolidated_schema}")
+    run_file(config, consolidated_schema)
+
+    if load_test_data is not None:
+        print(f"Loading test data from file {load_test_data}")
+        run_file(config, load_test_data)
+    else:
+        print("Skipping loading data.")
+
+
+def _create_template_database(mgmt_config, template_config, load_test_data: str):
+    '''Create a template database with schema and test data.
+
+    This template can be used to quickly create test databases via PostgreSQL's
+    CREATE DATABASE ... TEMPLATE feature, which is much faster than running
+    migrations for each test.
+    '''
+    global _template_dbs
+
+    template_key = _get_template_suffix(load_test_data)
+    template_db_name = template_config['database']
+
+    if template_key in _template_dbs:
+        print(f"Template database {template_db_name} already exists for this test data")
+        return
 
     maintenance_connection = psycopg2.connect(**mgmt_config)
     maintenance_connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
     maintenance_cursor = maintenance_connection.cursor()
 
-    if os.environ.get("HEVELIUS_DEBUG"):
-        maintenance_connection.autocommit = True
-
-    # If previous run failed and didn't cease the database, drop it.
     try:
-        drop_db_query = f"DROP DATABASE IF EXISTS {test_config['database']};"
+        # Drop template if it exists from a previous failed run
+        drop_db_query = f"DROP DATABASE IF EXISTS {template_db_name};"
         maintenance_cursor.execute(drop_db_query)
 
-        create_database_query = f"CREATE DATABASE {test_config['database']} OWNER {test_config['user']};"
+        # Create the template database
+        create_database_query = f"CREATE DATABASE {template_db_name} OWNER {template_config['user']};"
         maintenance_cursor.execute(create_database_query)
 
         maintenance_cursor.close()
         maintenance_connection.close()
     except Exception as e:
-        print(f"Failed to create DB. You might want to do (ALTER USER hevelius CREATEDB) and run again. Exception: {e}")
+        print(f"Failed to create template DB. Exception: {e}")
+        raise
 
-    _standard_seed_db(test_config, load_test_data)
+    # Seed the template database
+    _fast_seed_db(template_config, load_test_data)
+
+    _template_dbs[template_key] = template_db_name
+    print(f"Template database {template_db_name} created successfully")
+
+
+def _create_db_from_template(mgmt_config, test_config, template_db_name):
+    '''Create a test database from a template (very fast).'''
+    maintenance_connection = psycopg2.connect(**mgmt_config)
+    maintenance_connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    maintenance_cursor = maintenance_connection.cursor()
+
+    try:
+        # Drop test DB if it exists
+        drop_db_query = f"DROP DATABASE IF EXISTS {test_config['database']};"
+        maintenance_cursor.execute(drop_db_query)
+
+        # Create test database from template
+        create_database_query = f"CREATE DATABASE {test_config['database']} TEMPLATE {template_db_name} OWNER {test_config['user']};"
+        maintenance_cursor.execute(create_database_query)
+
+        maintenance_cursor.close()
+        maintenance_connection.close()
+    except Exception as e:
+        print(f"Failed to create test DB from template. Exception: {e}")
+        raise
+
+
+def _use_fast_tests():
+    '''Check if fast tests should be used.
+
+    Fast tests use a template database approach which is much faster.
+    Set HEVELIUS_SLOW_TESTS=1 to disable this and use incremental migrations.
+    '''
+    return not os.environ.get("HEVELIUS_SLOW_TESTS")
+
+
+@contextmanager
+def setup_database_test_case(*, load_test_data: str = None):
+    '''Create the test database, migrate it to the latest version, and
+    destroy after test case.
+
+    If HEVELIUS_SLOW_TESTS is not set (default), uses template database
+    approach for faster test execution. The template is created once per
+    test session with the consolidated schema.
+
+    If HEVELIUS_SLOW_TESTS=1, uses incremental migrations (slower but tests
+    the actual migration path).
+    '''
+    mgmt_config, test_config = _read_configuration()
+
+    use_fast = _use_fast_tests()
+
+    if use_fast:
+        # Template database approach (fast)
+        # Use different template for different test data files
+        template_suffix = _get_template_suffix(load_test_data)
+        template_db_name = test_config['database'] + "_tpl_" + template_suffix
+        template_config = {**test_config, 'database': template_db_name}
+
+        # Create template database if it doesn't exist
+        _create_template_database(mgmt_config, template_config, load_test_data)
+
+        # Create test database from template (very fast)
+        _create_db_from_template(mgmt_config, test_config, template_db_name)
+
+    else:
+        # Original slow approach with incremental migrations
+        maintenance_connection = psycopg2.connect(**mgmt_config)
+        maintenance_connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        maintenance_cursor = maintenance_connection.cursor()
+
+        if os.environ.get("HEVELIUS_DEBUG"):
+            maintenance_connection.autocommit = True
+
+        # If previous run failed and didn't cease the database, drop it.
+        try:
+            drop_db_query = f"DROP DATABASE IF EXISTS {test_config['database']};"
+            maintenance_cursor.execute(drop_db_query)
+
+            create_database_query = f"CREATE DATABASE {test_config['database']} OWNER {test_config['user']};"
+            maintenance_cursor.execute(create_database_query)
+
+            maintenance_cursor.close()
+            maintenance_connection.close()
+        except Exception as e:
+            print(f"Failed to create DB. You might want to do (ALTER USER hevelius CREATEDB) and run again. Exception: {e}")
+
+        _standard_seed_db(test_config, load_test_data)
 
     try:
         yield test_config
@@ -86,12 +218,44 @@ def setup_database_test_case(*, load_test_data: str = None):
         if os.environ.get("HEVELIUS_DEBUG"):
             print(f"HEVELIUS_DEBUG is set, not dropping the test database ({test_config['database']}).")
         else:
-            drop_database_query = f"DROP DATABASE {test_config['database']};"
-            print(f"HEVELIUS_DEBUG not set, dropping the test database ({test_config['database']}).")
+            drop_database_query = f"DROP DATABASE IF EXISTS {test_config['database']};"
+            print(f"Dropping the test database ({test_config['database']}).")
             maintenance_cursor.execute(drop_database_query)
 
         maintenance_cursor.close()
         maintenance_connection.close()
+
+
+def cleanup_template_database():
+    '''Clean up all template databases at the end of the test session.
+
+    This should be called by pytest's session-scoped fixture or manually
+    after all tests complete.
+    '''
+    global _template_dbs
+
+    if not _template_dbs:
+        return
+
+    mgmt_config, _ = _read_configuration()
+
+    try:
+        maintenance_connection = psycopg2.connect(**mgmt_config)
+        maintenance_connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        maintenance_cursor = maintenance_connection.cursor()
+
+        if not os.environ.get("HEVELIUS_DEBUG"):
+            for template_key, template_db_name in _template_dbs.items():
+                drop_db_query = f"DROP DATABASE IF EXISTS {template_db_name};"
+                maintenance_cursor.execute(drop_db_query)
+                print(f"Dropped template database {template_db_name}")
+
+        maintenance_cursor.close()
+        maintenance_connection.close()
+    except Exception as e:
+        print(f"Failed to drop template database: {e}")
+
+    _template_dbs.clear()
 
 
 def use_repository(f=None, *, load_test_data="tests/test-data.psql"):


### PR DESCRIPTION
The goals of this PR are:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a faster Postgres test setup flow using a consolidated schema and template databases.
> 
> - Adds `db/schema-consolidated.psql` (final schema v14) for test-only seeding
> - Updates `tests/dbtest.py` to seed via consolidated schema and create per-dataset template DBs, then clone test DBs from templates (fallback to incremental migrations or when `HEVELIUS_SLOW_TESTS=1`)
> - Cleans up test and template DBs; honors `HEVELIUS_DEBUG` to skip drops
> - Adds `tests/conftest.py` with a session-scoped fixture to auto-clean template databases after tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca5803ff5802c2fbb54b4e8cdcdf80e187ab2d69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->