### PR TITLE
Argon2id password handling implemented, md5 removed

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -851,7 +851,7 @@ paths:
                   description: Username
                 password:
                   type: string
-                  description: Password MD5 hash
+                  description: Password in plaintext (sent over HTTPS)
               required:
                 - username
                 - password

--- a/db/17-auth-argon2id-passd.psql
+++ b/db/17-auth-argon2id-passd.psql
@@ -1,0 +1,5 @@
+-- Upgrade `users.pass_d` to TEXT so it can store modern argon2id hashes.
+ALTER TABLE users ALTER COLUMN pass_d TYPE TEXT;
+
+UPDATE schema_version SET version = 17;
+

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -3,7 +3,10 @@ Flask application that provides a REST API to the Hevelius backend.
 """
 
 import logging
+import hashlib
+import hmac
 import os
+import re
 from flask import Flask, render_template, request
 
 from flask_cors import CORS
@@ -15,6 +18,8 @@ from marshmallow import Schema, fields, ValidationError, validate
 from flask.views import MethodView
 from datetime import datetime, timedelta
 from flask_jwt_extended import JWTManager, create_access_token, jwt_required, get_jwt_identity
+from argon2 import PasswordHasher, Type  # type: ignore[import-not-found]
+from argon2.exceptions import VerifyMismatchError, InvalidHashError  # type: ignore[import-not-found]
 
 from hevelius import cmd_stats, db, config as hevelius_config
 from hevelius.version import VERSION
@@ -76,7 +81,7 @@ class LoginRequestSchema(Schema):
     )
     password = fields.String(
         required=True,
-        metadata={"description": "Password MD5 hash"}
+        metadata={"description": "Password (plaintext, sent over HTTPS)"}
     )
 
 
@@ -94,6 +99,18 @@ class LoginResponseSchema(Schema):
     ftp_login = fields.String()
     ftp_pass = fields.String()
     msg = fields.String()
+
+
+# `password` in /api/login is plaintext. Legacy DB values may still be MD5 hex;
+# those are verified once and immediately replaced with argon2id.
+password_hasher = PasswordHasher(
+    time_cost=2,
+    memory_cost=65536,  # KiB
+    parallelism=1,
+    type=Type.ID,
+)
+
+_MD5_HEX_RE = re.compile(r"^[a-fA-F0-9]{32}$")
 
 
 class TaskAddRequestSchema(Schema):
@@ -629,11 +646,11 @@ class LoginResource(MethodView):
         Returns user information and JWT token if credentials are valid
         """
         user = login_data.get('username')
-        md5pass = login_data.get('password')
+        password = login_data.get('password')
 
         if user is None:
             return {'status': False, 'msg': 'Username not provided'}
-        if md5pass is None:
+        if password is None:
             return {'status': False, 'msg': 'Password not provided'}
 
         query = """SELECT user_id, pass_d, login, firstname, lastname, share, phone, email, permissions,
@@ -658,10 +675,45 @@ class LoginResource(MethodView):
         user_id, pass_db, _, firstname, lastname, share, phone, email, permissions, aavso_id, \
             ftp_login, ftp_pass = db_resp[0]
 
-        if md5pass.lower() != pass_db.lower():
-            print(f"Login: Invalid password for user ({user})")
-            # Password's MD5 did not match
+        # Legacy: `pass_d` stored as MD5 hex (case-insensitive). Upgrade to argon2id lazily
+        # after successful login.
+        if pass_db is None:
+            print(f"Login: Missing pass_d for user ({user})")
             return {'status': False, 'msg': 'Invalid credentials'}
+
+        if isinstance(pass_db, str) and _MD5_HEX_RE.fullmatch(pass_db):
+            legacy_md5 = hashlib.md5(password.encode("utf-8")).hexdigest()
+            if not hmac.compare_digest(legacy_md5.lower(), pass_db.lower()):
+                print(f"Login: Invalid legacy MD5 password for user ({user})")
+                return {'status': False, 'msg': 'Invalid credentials'}
+
+            # Successful legacy verification: replace with argon2id hash.
+            pass_d_new = password_hasher.hash(password)
+            cnx = db.connect()
+            db.run_query(cnx, "UPDATE users SET pass_d=%s WHERE user_id=%s", (pass_d_new, user_id))
+            cnx.close()
+        else:
+            # New format: argon2id hash string (stored format is self-describing).
+            if not (isinstance(pass_db, str) and pass_db.startswith("$argon2")):
+                print(f"Login: Unsupported pass_d format for user ({user})")
+                return {'status': False, 'msg': 'Invalid credentials'}
+
+            try:
+                password_hasher.verify(pass_db, password)
+            except (VerifyMismatchError, InvalidHashError):
+                print(f"Login: Invalid argon2id password for user ({user})")
+                return {'status': False, 'msg': 'Invalid credentials'}
+
+            # Future re-hashing: upgrade transparently if params are weak/changed.
+            try:
+                if password_hasher.check_needs_rehash(pass_db):
+                    pass_d_new = password_hasher.hash(password)
+                    cnx = db.connect()
+                    db.run_query(cnx, "UPDATE users SET pass_d=%s WHERE user_id=%s", (pass_d_new, user_id))
+                    cnx.close()
+            except InvalidHashError:
+                print(f"Login: Invalid argon2id hash for user ({user})")
+                return {'status': False, 'msg': 'Invalid credentials'}
 
         # Create JWT access token
         access_token = create_access_token(

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,6 @@ flask-cors
 flask-smorest
 flask-jwt-extended
 
+argon2-cffi
+
 PyJWT==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,3 +85,5 @@ werkzeug==3.1.6
     #   flask-cors
     #   flask-jwt-extended
     #   flask-smorest
+
+argon2-cffi

--- a/tests/dbtest.py
+++ b/tests/dbtest.py
@@ -159,7 +159,9 @@ def setup_database_test_case(*, load_test_data: str = None):
         raise
 
     if load_test_data is not None:
-        print(f"Loading test data from file {load_test_data}")
+        if os.environ.get("HEVELIUS_DEBUG") == "1":
+            print(f"Loading test data from file {load_test_data}")
+
         run_file(test_config, load_test_data)
         # Reset sequences so next INSERT gets a new id (test data uses explicit ids)
         _reset_sequences_after_load(test_config)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -26,7 +26,7 @@ class DbTest(unittest.TestCase):
         version = db.version_get(conn)
         conn.close()
 
-        self.assertEqual(version, 16)
+        self.assertEqual(version, 17)
 
     @use_repository
     def test_sensor(self, config):

--- a/tests/test_login_argon2id.py
+++ b/tests/test_login_argon2id.py
@@ -1,0 +1,141 @@
+import json
+import os
+import sys
+import unittest
+import hashlib
+from pathlib import Path
+
+# Ensure repo root is on PYTHONPATH so `tests.*` and `heveliusbackend.*` imports work
+# consistently under different test runners.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from argon2 import PasswordHasher, Type
+
+from hevelius import db
+from tests.dbtest import use_repository
+
+from heveliusbackend.app import app, password_hasher  # noqa: E402
+
+
+class TestLoginArgon2id(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+        self.client.testing = True
+
+    @use_repository(load_test_data=None)
+    def test_lazy_migration_from_md5(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+
+        plaintext_password = "correct horse battery staple"
+        legacy_md5 = hashlib.md5(plaintext_password.encode("utf-8")).hexdigest()
+        login = "legacy_user"
+
+        cnx = db.connect(config)
+        db.run_query(
+            cnx,
+            """
+            INSERT INTO users (user_id, login, pass, firstname, lastname, share, phone, email,
+                                permissions, aavso_id, ftp_login, ftp_pass, pass_d)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                200,
+                login,
+                "pass",
+                "Legacy",
+                "User",
+                1.0,
+                "",
+                "legacy@example.com",
+                1,
+                "AAVSO",
+                "ftp_login",
+                "ftp_pass",
+                legacy_md5.upper(),  # ensure case-insensitive compare
+            ),
+        )
+        cnx.close()
+
+        response = self.client.post(
+            "/api/login",
+            data=json.dumps({"username": login, "password": plaintext_password}),
+            headers={"Content-Type": "application/json"},
+        )
+        data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["status"])
+        self.assertIn("token", data)
+
+        cnx = db.connect(config)
+        pass_d_after = db.run_query(
+            cnx, "SELECT pass_d FROM users WHERE user_id=%s", (200,)
+        )[0][0]
+        cnx.close()
+
+        self.assertTrue(isinstance(pass_d_after, str))
+        self.assertTrue(pass_d_after.startswith("$argon2id$"))
+
+        # Clean up to match other tests' behavior.
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository(load_test_data=None)
+    def test_rehash_when_argon2_params_are_weak(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+
+        plaintext_password = "super secret password"
+        login = "weak_argon2_user"
+
+        weak_hasher = PasswordHasher(time_cost=1, memory_cost=1024, parallelism=1, type=Type.ID)
+        weak_hash = weak_hasher.hash(plaintext_password)
+
+        cnx = db.connect(config)
+        db.run_query(
+            cnx,
+            """
+            INSERT INTO users (user_id, login, pass, firstname, lastname, share, phone, email,
+                                permissions, aavso_id, ftp_login, ftp_pass, pass_d)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                201,
+                login,
+                "pass",
+                "Weak",
+                "Argon2",
+                1.0,
+                "",
+                "weak@example.com",
+                1,
+                "AAVSO",
+                "ftp_login",
+                "ftp_pass",
+                weak_hash,
+            ),
+        )
+        cnx.close()
+
+        self.assertTrue(password_hasher.check_needs_rehash(weak_hash))
+
+        response = self.client.post(
+            "/api/login",
+            data=json.dumps({"username": login, "password": plaintext_password}),
+            headers={"Content-Type": "application/json"},
+        )
+        data = json.loads(response.data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["status"])
+
+        cnx = db.connect(config)
+        pass_d_after = db.run_query(
+            cnx, "SELECT pass_d FROM users WHERE user_id=%s", (201,)
+        )[0][0]
+        cnx.close()
+
+        self.assertTrue(isinstance(pass_d_after, str))
+        self.assertTrue(pass_d_after.startswith("$argon2id$"))
+        self.assertNotEqual(pass_d_after, weak_hash)
+
+        os.environ.pop("HEVELIUS_DB_NAME")
+

--- a/tests/test_login_argon2id.py
+++ b/tests/test_login_argon2id.py
@@ -1,7 +1,6 @@
 import json
 import os
 import unittest
-import hashlib
 
 from argon2 import PasswordHasher, Type
 
@@ -21,7 +20,8 @@ class TestLoginArgon2id(unittest.TestCase):
         os.environ["HEVELIUS_DB_NAME"] = config["database"]
 
         plaintext_password = "correct horse battery staple"
-        legacy_md5 = hashlib.md5(plaintext_password.encode("utf-8")).hexdigest()
+        # Precomputed MD5 hash of "correct horse battery staple"
+        legacy_md5 = "1c53a89c8db7a2bd840beba496839cdf"
         login = "legacy_user"
 
         cnx = db.connect(config)

--- a/tests/test_login_argon2id.py
+++ b/tests/test_login_argon2id.py
@@ -1,13 +1,7 @@
 import json
 import os
-import sys
 import unittest
 import hashlib
-from pathlib import Path
-
-# Ensure repo root is on PYTHONPATH so `tests.*` and `heveliusbackend.*` imports work
-# consistently under different test runners.
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from argon2 import PasswordHasher, Type
 
@@ -128,9 +122,7 @@ class TestLoginArgon2id(unittest.TestCase):
         self.assertTrue(data["status"])
 
         cnx = db.connect(config)
-        pass_d_after = db.run_query(
-            cnx, "SELECT pass_d FROM users WHERE user_id=%s", (201,)
-        )[0][0]
+        pass_d_after = db.run_query(cnx, "SELECT pass_d FROM users WHERE user_id=%s", (201,))[0][0]
         cnx.close()
 
         self.assertTrue(isinstance(pass_d_after, str))
@@ -138,4 +130,3 @@ class TestLoginArgon2id(unittest.TestCase):
         self.assertNotEqual(pass_d_after, weak_hash)
 
         os.environ.pop("HEVELIUS_DB_NAME")
-

--- a/tests/test_login_argon2id.py
+++ b/tests/test_login_argon2id.py
@@ -21,7 +21,7 @@ class TestLoginArgon2id(unittest.TestCase):
 
         plaintext_password = "correct horse battery staple"
         # Precomputed MD5 hash of "correct horse battery staple"
-        legacy_md5 = "1c53a89c8db7a2bd840beba496839cdf"
+        legacy_md5 = "9cc2ae8a1ba7a93da39b46fc1019c481"
         login = "legacy_user"
 
         cnx = db.connect(config)


### PR DESCRIPTION
Migrated to modern crypto - using argon2id password hashes. The MD5 support is kept only for migration of old passwords.