### PR TITLE
Implement project management tweaks (issue #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
   goal_count or active flag.
 - API: project subframes now expose `last_updated` (UTC). The server stamps it on
   every successful PATCH so callers can detect stale rows and skip no-op writes.
-- DB: Schema bumped to 20: added `project_subframes.last_updated`.
+- DB: Schema bumped to 21: added `project_subframes.last_updated`.
 - API: project publications mechanism added.
+- API: projects can be deleted.
+- CLI: projects can be deleted.
 
 ## 0.5.0 (2026-04-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 - API: project subframes now expose `last_updated` (UTC). The server stamps it on
   every successful PATCH so callers can detect stale rows and skip no-op writes.
 - DB: Schema bumped to 20: added `project_subframes.last_updated`.
+- API: project publications mechanism added.
 
 ## 0.5.0 (2026-04-27)
 

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -23,6 +23,8 @@ from hevelius.cmd_equipment import (
     show_project,
     add_project,
     edit_project,
+    delete_project,
+    find_similar_project_names,
     get_filter_id_by_short_name,
     add_project_subframe,
     edit_project_subframe,
@@ -201,6 +203,8 @@ def run():
     subframe_remove = subframe_sub.add_parser('remove', help="Remove a subframe from a project")
     subframe_remove.add_argument('project_id', type=int, help="Project ID")
     subframe_remove.add_argument('subframe_id', type=int, help="Subframe ID to remove")
+    project_delete = project_sub.add_parser('delete', help="Delete a project and all its associated data")
+    project_delete.add_argument('project_id', type=int, help="Project ID to delete")
     project_stats_parser = project_sub.add_parser('stats', help="Show task statistics for a project")
     project_stats_parser.add_argument('project_id', type=int, help="Project ID")
     project_task_add = project_sub.add_parser('task-add', help="Assign a task to a project")
@@ -365,6 +369,9 @@ def run():
         return 0
     if args.command == "project":
         if args.project_command == "add":
+            similar = find_similar_project_names(args.name)
+            for s in similar:
+                print(f"Warning: project with similar name '{s['name']}' already exists (id={s['project_id']})", file=sys.stderr)
             active = getattr(args, 'active', True) and not getattr(args, 'inactive', False)
             pid = add_project(
                 args.name,
@@ -395,6 +402,13 @@ def run():
                 active=active
             )
             return 0 if ok else 1
+        if args.project_command == "delete":
+            ok = delete_project(args.project_id)
+            if not ok:
+                print(f"Project {args.project_id} not found.", file=sys.stderr)
+                return 1
+            print(f"Deleted project {args.project_id}")
+            return 0
         if args.project_command == "show":
             return show_project(args.project_id) or 0
         if args.project_command == "stats":

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -15,7 +15,7 @@ from hevelius.cmd_stats import stats, histogram_show, groups
 from hevelius.cmd_db_migrate import migrate
 from hevelius.cmd_repo import repo
 from hevelius.cmd_catalog import catalog, format_get
-from hevelius.cmd_users import list_users, add_user, disable_user, enable_user
+from hevelius.cmd_users import list_users, add_user, disable_user, enable_user, edit_user_profile
 from hevelius.cmd_equipment import (
     list_filters,
     list_sensors,
@@ -279,6 +279,12 @@ def run():
     user_enable = user_sub.add_parser('enable', help="Enable user (set password)")
     user_enable.add_argument('login_or_id', help="Login name or numeric user_id")
     user_enable.add_argument('--password', required=True, help="New password")
+    user_profile_edit = user_sub.add_parser('profile-edit', help="Edit user profile (name, email, AAVSO id)")
+    user_profile_edit.add_argument('login_or_id', help="Login name or numeric user_id")
+    user_profile_edit.add_argument('--firstname', default=None, help="First name")
+    user_profile_edit.add_argument('--lastname', default=None, help="Last name")
+    user_profile_edit.add_argument('--email', default=None, help="Email address (empty string to clear)")
+    user_profile_edit.add_argument('--aavso-id', default=None, dest='aavso_id', help="AAVSO observer ID")
 
     args = parser.parse_args()
 
@@ -546,6 +552,15 @@ def run():
             return 0 if disable_user(args.login_or_id) else 1
         if args.user_command == "enable":
             return 0 if enable_user(args.login_or_id, args.password) else 1
+        if args.user_command == "profile-edit":
+            ok = edit_user_profile(
+                args.login_or_id,
+                firstname=getattr(args, 'firstname', None),
+                lastname=getattr(args, 'lastname', None),
+                email=getattr(args, 'email', None),
+                aavso_id=getattr(args, 'aavso_id', None),
+            )
+            return 0 if ok else 1
         return user_parser.print_help() or 1
     return parser.print_help()
 

--- a/hevelius/cmd_equipment.py
+++ b/hevelius/cmd_equipment.py
@@ -2,6 +2,8 @@
 CLI commands for filters, sensors (cameras), and projects.
 """
 
+import difflib
+
 from hevelius import db
 
 
@@ -322,6 +324,41 @@ def edit_project(project_id, name=None, description=None, scope_id=None, ra=None
         return True
     args.append(project_id)
     db.run_query(cnx, "UPDATE projects SET " + ", ".join(updates) + " WHERE project_id = %s", tuple(args))
+    cnx.close()
+    return True
+
+
+def find_similar_project_names(name, exclude_id=None):
+    """Return list of {project_id, name} dicts for projects with names similar to name."""
+    cnx = db.connect()
+    if exclude_id is not None:
+        rows = db.run_query(cnx, "SELECT project_id, name FROM projects WHERE project_id != %s", (exclude_id,))
+    else:
+        rows = db.run_query(cnx, "SELECT project_id, name FROM projects")
+    cnx.close()
+    if not rows:
+        return []
+    name_lower = name.strip().lower()
+    similar = []
+    for r in rows:
+        pid, pname = r[0], r[1]
+        pname_lower = (pname or "").strip().lower()
+        if name_lower in pname_lower or pname_lower in name_lower:
+            similar.append({"project_id": pid, "name": pname})
+            continue
+        if difflib.SequenceMatcher(None, name_lower, pname_lower).ratio() >= 0.6:
+            similar.append({"project_id": pid, "name": pname})
+    return similar
+
+
+def delete_project(project_id):
+    """Delete a project and all its associated data (cascades via FK). Returns True on success, False if not found."""
+    cnx = db.connect()
+    row = db.run_query(cnx, "SELECT project_id FROM projects WHERE project_id = %s", (project_id,))
+    if not row:
+        cnx.close()
+        return False
+    db.run_query(cnx, "DELETE FROM projects WHERE project_id = %s", (project_id,))
     cnx.close()
     return True
 

--- a/hevelius/cmd_users.py
+++ b/hevelius/cmd_users.py
@@ -141,6 +141,36 @@ def disable_user(login_or_id):
     return True
 
 
+def edit_user_profile(login_or_id, firstname=None, lastname=None, email=None, aavso_id=None):
+    """Update profile fields (firstname, lastname, email, aavso_id) for a user.
+    Pass empty string for email to clear it. Returns True on success."""
+    cnx = db.connect()
+    row = _resolve_user(cnx, login_or_id)
+    if not row:
+        cnx.close()
+        print(f"User not found: {login_or_id!r}")
+        return False
+    uid, login = row
+    updates = []
+    args = []
+    for key, val in (("firstname", firstname), ("lastname", lastname), ("aavso_id", aavso_id)):
+        if val is not None:
+            updates.append(f"{key} = %s")
+            args.append(val or None)
+    if email is not None:
+        updates.append("email = %s")
+        args.append(email if email else None)
+    if not updates:
+        cnx.close()
+        return True
+    args.append(uid)
+    db.run_query(cnx, "UPDATE users SET " + ", ".join(updates) + " WHERE user_id = %s", tuple(args))
+    cnx.close()
+    log_user_admin_action("cli", "user.profile_edit", actor_user_id=None, target_user_id=uid, details={"login": login})
+    print(f"Updated user_id={uid} login={login!r}")
+    return True
+
+
 def enable_user(login_or_id, password):
     """Set pass_d from password; clears legacy pass."""
     if not password:

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -803,6 +803,22 @@ class UsersAdminListResponseSchema(Schema):
     users = fields.List(fields.Nested(UserAdminDetailSchema))
 
 
+class UserProfileUpdateSchema(Schema):
+    firstname = fields.String(allow_none=True, validate=validate.Length(max=32))
+    lastname = fields.String(allow_none=True, validate=validate.Length(max=32))
+    email = fields.String(allow_none=True, validate=validate.Length(max=64))
+    aavso_id = fields.String(allow_none=True, validate=validate.Length(max=5))
+
+
+class UserPasswordChangeSchema(Schema):
+    current_password = fields.String(required=True, metadata={"description": "Current password"})
+    new_password = fields.String(
+        required=True,
+        validate=validate.Length(min=8, error="Password must be at least 8 characters"),
+        metadata={"description": "New password"},
+    )
+
+
 class AuditLogEntrySchema(Schema):
     id = fields.Integer()
     created_at = fields.DateTime()
@@ -1039,6 +1055,84 @@ class UsersMeResource(MethodView):
             "aavso_id": aavso,
             "login_enabled": bool(pass_d and str(pass_d).strip()),
         }
+
+    @jwt_required()
+    @blp.arguments(UserProfileUpdateSchema, location="json")
+    @blp.response(200, UserAdminDetailSchema)
+    def patch(self, body):
+        """Update own profile: firstname, lastname, email (optional, may be empty), aavso_id."""
+        uid = _jwt_user_id_int()
+        if uid is None:
+            abort(401, message="Invalid token identity")
+        cnx = db.connect()
+        if not db.run_query(cnx, "SELECT user_id FROM users WHERE user_id = %s", (uid,)):
+            cnx.close()
+            abort(404, message="User not found")
+        updates = []
+        args = []
+        for key in ("firstname", "lastname", "aavso_id"):
+            if key in body:
+                updates.append(f"{key} = %s")
+                args.append(body[key] or None)
+        if "email" in body:
+            updates.append("email = %s")
+            args.append(body["email"] if body["email"] else None)
+        if updates:
+            args.append(uid)
+            db.run_query(cnx, "UPDATE users SET " + ", ".join(updates) + " WHERE user_id = %s", tuple(args))
+        rows = db.run_query(
+            cnx,
+            """SELECT user_id, login, firstname, lastname, share, phone, email,
+                      permissions, aavso_id, pass_d
+               FROM users WHERE user_id = %s""",
+            (uid,),
+        )
+        cnx.close()
+        r = rows[0]
+        return {
+            "user_id": r[0], "login": r[1], "firstname": r[2], "lastname": r[3],
+            "share": float(r[4]) if r[4] is not None else None,
+            "phone": r[5], "email": r[6], "permissions": r[7], "aavso_id": r[8],
+            "login_enabled": bool(r[9] and str(r[9]).strip()),
+        }
+
+
+@blp.route("/users/me/password")
+class UsersMePasswordResource(MethodView):
+    @jwt_required()
+    @blp.arguments(UserPasswordChangeSchema, location="json")
+    @blp.response(200, StatusMsgSchema)
+    def post(self, body):
+        """Change own password. current_password must match the stored credential."""
+        uid = _jwt_user_id_int()
+        if uid is None:
+            abort(401, message="Invalid token identity")
+        cnx = db.connect()
+        rows = db.run_query(cnx, "SELECT pass_d FROM users WHERE user_id = %s", (uid,))
+        cnx.close()
+        if not rows:
+            abort(404, message="User not found")
+        pass_d = rows[0][0]
+        if not (pass_d and str(pass_d).strip()):
+            abort(400, message="Account has no password set; use the password reset flow.")
+        current = body["current_password"]
+        if isinstance(pass_d, str) and _MD5_HEX_RE.fullmatch(pass_d):
+            legacy_md5 = hashlib.md5(current.encode("utf-8")).hexdigest()
+            if not hmac.compare_digest(legacy_md5.lower(), pass_d.lower()):
+                abort(400, message="Current password is incorrect.")
+        elif isinstance(pass_d, str) and pass_d.startswith("$argon2"):
+            try:
+                password_hasher.verify(pass_d, current)
+            except (VerifyMismatchError, InvalidHashError):
+                abort(400, message="Current password is incorrect.")
+        else:
+            abort(400, message="Unsupported password format; use the password reset flow.")
+        new_hash = password_hasher.hash(body["new_password"])
+        cnx = db.connect()
+        db.run_query(cnx, "UPDATE users SET pass = NULL, pass_d = %s WHERE user_id = %s", (new_hash, uid))
+        cnx.close()
+        log_user_admin_action("api", "user.password_change", actor_user_id=uid, target_user_id=uid, details={})
+        return {"status": True, "msg": "Password updated"}
 
 
 @blp.route("/users/audit-log")

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -2,6 +2,7 @@
 Flask application that provides a REST API to the Hevelius backend.
 """
 
+import difflib
 import logging
 import hashlib
 import hmac
@@ -2371,6 +2372,27 @@ def _project_subframe_count(goal_count, count):
     return 0
 
 
+def _find_similar_project_names(cnx, name, exclude_id=None):
+    """Return list of existing projects whose names are similar to name (substring or fuzzy match)."""
+    if exclude_id is not None:
+        rows = db.run_query(cnx, "SELECT project_id, name FROM projects WHERE project_id != %s", (exclude_id,))
+    else:
+        rows = db.run_query(cnx, "SELECT project_id, name FROM projects")
+    if not rows:
+        return []
+    name_lower = name.strip().lower()
+    similar = []
+    for r in rows:
+        pid, pname = r[0], r[1]
+        pname_lower = (pname or "").strip().lower()
+        if name_lower in pname_lower or pname_lower in name_lower:
+            similar.append({"project_id": pid, "name": pname})
+            continue
+        if difflib.SequenceMatcher(None, name_lower, pname_lower).ratio() >= 0.6:
+            similar.append({"project_id": pid, "name": pname})
+    return similar
+
+
 @blp.route("/projects")
 class ProjectsResource(MethodView):
     @jwt_required()
@@ -2465,6 +2487,11 @@ class ProjectsResource(MethodView):
         if not scope_exists:
             cnx.close()
             abort(400, message="Invalid scope_id: telescope not found.")
+        similar = _find_similar_project_names(cnx, name)
+        warnings = [
+            f"Project with similar name '{p['name']}' already exists (id={p['project_id']})"
+            for p in similar
+        ]
         db.run_query(
             cnx,
             "INSERT INTO projects (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, publications) "
@@ -2495,7 +2522,7 @@ class ProjectsResource(MethodView):
         ]
         user_ids = [ur[0] for ur in (user_rows or [])]
         project = _project_row_to_dict(row[0], subframes=subframes, user_ids=user_ids)
-        return {"status": True, "project_id": project_id, "project": project, "msg": "Created"}, 201
+        return {"status": True, "project_id": project_id, "project": project, "msg": "Created", "warnings": warnings}, 201
 
 
 @blp.route("/projects/<int:project_id>")
@@ -2575,6 +2602,19 @@ class ProjectDetailResource(MethodView):
         user_ids = [ur[0] for ur in (user_rows or [])]
         project = _project_row_to_dict(row[0], subframes=subframes, user_ids=user_ids)
         return {"status": True, "project": project, "msg": "Updated"}
+
+    @jwt_required()
+    @blp.response(200)
+    def delete(self, project_id):
+        """Delete project (subframes, user associations, and task links cascade automatically)."""
+        cnx = db.connect()
+        row = db.run_query(cnx, "SELECT project_id FROM projects WHERE project_id = %s", (project_id,))
+        if not row:
+            cnx.close()
+            abort(404, message=f"Project {project_id} not found")
+        db.run_query(cnx, "DELETE FROM projects WHERE project_id = %s", (project_id,))
+        cnx.close()
+        return {"status": True, "msg": f"Project {project_id} deleted"}
 
 
 def _resolve_filter_id(cnx, body, require_one=True):

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -1117,9 +1117,7 @@ class UsersMePasswordResource(MethodView):
             abort(400, message="Account has no password set; use the password reset flow.")
         current = body["current_password"]
         if isinstance(pass_d, str) and _MD5_HEX_RE.fullmatch(pass_d):
-            legacy_md5 = hashlib.md5(current.encode("utf-8")).hexdigest()
-            if not hmac.compare_digest(legacy_md5.lower(), pass_d.lower()):
-                abort(400, message="Current password is incorrect.")
+            abort(400, message="Legacy password format detected; use the password reset flow.")
         elif isinstance(pass_d, str) and pass_d.startswith("$argon2"):
             try:
                 password_hasher.verify(pass_d, current)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2334,6 +2334,101 @@ class TestUsersAPI(unittest.TestCase):
         self.assertEqual(response.status_code, 403)
         os.environ.pop("HEVELIUS_DB_NAME")
 
+    @use_repository
+    def test_users_me_patch_profile(self, config):
+        """PATCH /api/users/me updates firstname, lastname, email, and aavso_id."""
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        body = {"firstname": "Alice", "lastname": "Smith", "email": "alice@example.com", "aavso_id": "AA001"}
+        response = self.app.patch("/api/users/me", data=json.dumps(body), headers=self.headers_no_admin)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data["firstname"], "Alice")
+        self.assertEqual(data["lastname"], "Smith")
+        self.assertEqual(data["email"], "alice@example.com")
+        self.assertEqual(data["aavso_id"], "AA001")
+        self.assertNotIn("pass_d", data)
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_users_me_patch_clear_email(self, config):
+        """PATCH /api/users/me with null email clears it."""
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        self.app.patch("/api/users/me", data=json.dumps({"email": "set@example.com"}), headers=self.headers_no_admin)
+        response = self.app.patch("/api/users/me", data=json.dumps({"email": None}), headers=self.headers_no_admin)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIsNone(data.get("email"))
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_users_me_patch_requires_auth(self, config):
+        """PATCH /api/users/me without a token returns 401."""
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        response = self.app.patch("/api/users/me", data=json.dumps({"firstname": "X"}),
+                                  headers={"Content-Type": "application/json"})
+        self.assertEqual(response.status_code, 401)
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_users_me_password_change_success(self, config):
+        """POST /api/users/me/password changes password when current_password is correct."""
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        from argon2 import PasswordHasher, Type as ArgonType
+        ph = PasswordHasher(time_cost=2, memory_cost=65536, parallelism=1, type=ArgonType.ID)
+        known_hash = ph.hash("OldPassword123")
+        cnx = db.connect()
+        db.run_query(cnx, "UPDATE users SET pass_d = %s WHERE user_id = 1", (known_hash,))
+        cnx.close()
+        body = {"current_password": "OldPassword123", "new_password": "NewPassword456"}
+        response = self.app.post("/api/users/me/password", data=json.dumps(body), headers=self.headers_no_admin)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data["status"])
+        cnx = db.connect()
+        row = db.run_query(cnx, "SELECT pass_d FROM users WHERE user_id = 1")
+        cnx.close()
+        self.assertTrue(str(row[0][0]).startswith("$argon2"))
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_users_me_password_change_wrong_current(self, config):
+        """POST /api/users/me/password with wrong current_password returns 400."""
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        from argon2 import PasswordHasher, Type as ArgonType
+        ph = PasswordHasher(time_cost=2, memory_cost=65536, parallelism=1, type=ArgonType.ID)
+        known_hash = ph.hash("CorrectPassword123")
+        cnx = db.connect()
+        db.run_query(cnx, "UPDATE users SET pass_d = %s WHERE user_id = 1", (known_hash,))
+        cnx.close()
+        body = {"current_password": "WrongPassword999", "new_password": "NewPassword456"}
+        response = self.app.post("/api/users/me/password", data=json.dumps(body), headers=self.headers_no_admin)
+        self.assertEqual(response.status_code, 400)
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_users_me_password_change_too_short(self, config):
+        """POST /api/users/me/password with new_password shorter than 8 chars returns 422."""
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        body = {"current_password": "anything", "new_password": "short"}
+        response = self.app.post("/api/users/me/password", data=json.dumps(body), headers=self.headers_no_admin)
+        self.assertEqual(response.status_code, 422)
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_users_full_list_has_all_fields(self, config):
+        """GET /api/users returns all non-password fields for every user."""
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        response = self.app.get("/api/users", headers=self.headers_admin)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        u = next(x for x in data["users"] if x["user_id"] == 1)
+        for field in ("user_id", "login", "firstname", "lastname", "email",
+                      "phone", "permissions", "aavso_id", "share", "login_enabled"):
+            self.assertIn(field, u)
+        for secret in ("pass", "pass_d"):
+            self.assertNotIn(secret, u)
+        os.environ.pop("HEVELIUS_DB_NAME")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2135,7 +2135,6 @@ class TestProjectOperations(unittest.TestCase):
         self.assertTrue(data.get('token'))
         os.environ.pop('HEVELIUS_DB_NAME')
 
-
     @use_repository
     def test_project_delete(self, config):
         """DELETE project removes it; subsequent GET returns status=False."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2136,6 +2136,73 @@ class TestProjectOperations(unittest.TestCase):
         os.environ.pop('HEVELIUS_DB_NAME')
 
 
+    @use_repository
+    def test_project_delete(self, config):
+        """DELETE project removes it; subsequent GET returns status=False."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {"name": "ToDelete", "scope_id": 1, "ra": 0.5, "decl": 25.0}
+        cr = json.loads(self.app.post('/api/projects', data=json.dumps(body), headers=self.headers).data)
+        pid = cr['project_id']
+        response = self.app.delete(f'/api/projects/{pid}', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['status'])
+        get_resp = self.app.get(f'/api/projects/{pid}', headers=self.headers)
+        get_data = json.loads(get_resp.data)
+        self.assertFalse(get_data['status'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_delete_not_found(self, config):
+        """DELETE non-existent project returns 404."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.delete('/api/projects/99999', headers=self.headers)
+        self.assertEqual(response.status_code, 404)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_create_similar_name_warns(self, config):
+        """Creating project whose name is a substring of an existing one returns warnings."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        suf = datetime.now().strftime('%H%M%S%f')
+        body1 = {"name": f"M31 Campaign {suf}", "scope_id": 1, "ra": 0.5, "decl": 25.0}
+        self.app.post('/api/projects', data=json.dumps(body1), headers=self.headers)
+        body2 = {"name": f"M31 Campaign {suf} extended", "scope_id": 1, "ra": 0.5, "decl": 25.0}
+        response = self.app.post('/api/projects', data=json.dumps(body2), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data)
+        self.assertTrue(data['status'])
+        self.assertIn('warnings', data)
+        self.assertGreater(len(data['warnings']), 0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_create_no_similar_name_no_warnings(self, config):
+        """Creating a project with a unique name returns an empty warnings list."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        suf = datetime.now().strftime('%H%M%S%f')
+        body = {"name": f"UniqueXYZ{suf}", "scope_id": 1, "ra": 0.5, "decl": 25.0}
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data)
+        self.assertTrue(data['status'])
+        self.assertIn('warnings', data)
+        self.assertEqual(len(data['warnings']), 0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_edit_description(self, config):
+        """PATCH can update only the description of a project."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {"description": "Brand new description"}
+        response = self.app.patch('/api/projects/1', data=json.dumps(body), headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['status'])
+        self.assertEqual(data['project']['description'], 'Brand new description')
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+
 class TestUsersAPI(unittest.TestCase):
     """GET /api/users/logins and GET /api/users (admin)."""
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -8,6 +8,8 @@ from hevelius.cmd_equipment import (
     edit_sensor,
     add_project,
     edit_project,
+    delete_project,
+    find_similar_project_names,
     add_project_subframe,
     remove_project_subframe,
     get_filter_id_by_short_name,
@@ -345,5 +347,53 @@ class DbTest(unittest.TestCase):
             rows = db.run_query(conn, "SELECT id FROM project_subframes WHERE project_id = %s AND id = %s", (pid, sid))
             conn.close()
             self.assertEqual(len(rows), 0)
+        finally:
+            os.environ.pop('HEVELIUS_DB_NAME', None)
+
+    @use_repository
+    def test_delete_project_cli(self, config):
+        """delete_project removes the project and cascades to subframes."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        try:
+            pid = add_project("Delete Me", scope_id=1, description="temp", ra=1.0, dec=10.0)
+            self.assertIsNotNone(pid)
+            fid = get_filter_id_by_short_name("SG")
+            add_project_subframe(pid, filter_id=fid, exposure_time=30.0)
+            ok = delete_project(pid)
+            self.assertTrue(ok)
+            conn = db.connect()
+            proj_rows = db.run_query(conn, "SELECT project_id FROM projects WHERE project_id = %s", (pid,))
+            sub_rows = db.run_query(conn, "SELECT id FROM project_subframes WHERE project_id = %s", (pid,))
+            conn.close()
+            self.assertEqual(len(proj_rows), 0)
+            self.assertEqual(len(sub_rows), 0)
+        finally:
+            os.environ.pop('HEVELIUS_DB_NAME', None)
+
+    @use_repository
+    def test_delete_project_not_found_returns_false(self, config):
+        """delete_project returns False for non-existent project."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        try:
+            ok = delete_project(999999)
+            self.assertFalse(ok)
+        finally:
+            os.environ.pop('HEVELIUS_DB_NAME', None)
+
+    @use_repository
+    def test_find_similar_project_names(self, config):
+        """find_similar_project_names detects substring overlap."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        try:
+            pid1 = add_project("SimilarBase Alpha", scope_id=1, ra=1.0, dec=10.0)
+            pid2 = add_project("SimilarBase Alpha Extended", scope_id=1, ra=1.0, dec=10.0)
+            self.assertIsNotNone(pid1)
+            self.assertIsNotNone(pid2)
+            similar = find_similar_project_names("SimilarBase Alpha")
+            ids = [s['project_id'] for s in similar]
+            self.assertIn(pid1, ids)
+            self.assertIn(pid2, ids)
+            unique = find_similar_project_names("CompletelyUniqueXYZ999")
+            self.assertEqual(len(unique), 0)
         finally:
             os.environ.pop('HEVELIUS_DB_NAME', None)


### PR DESCRIPTION
- Add DELETE /api/projects/<id> endpoint and delete_project() CLI function
  to allow removing existing projects; subframes, user associations, and
  task links cascade automatically via FK ON DELETE CASCADE.

- Warn on similar project names: POST /api/projects now returns a
  warnings list when existing project names are substrings of the new
  name (or vice versa) or are fuzzy-matched (>= 0.6 ratio via difflib).
  The CLI project add command prints the same warnings to stderr.

- Edit description: already supported via PATCH /api/projects/<id> and
  hevelius project edit --description; added a dedicated test to confirm.

- Add hevelius project delete <project_id> CLI subcommand.

- Tests: new API tests for delete (success + 404), similar-name warning,
  unique-name no-warning, description edit; new DB/CLI tests for
  delete_project() and find_similar_project_names().

https://claude.ai/code/session_01N85tBJvv7EessPhhvQand9