### PR TITLE
Catalog, catalogs commands implemented in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 
 - CLI: `hevelius catalogs` lists installed catalogs with object counts (`--sort entries|name`).
 - CLI: `hevelius catalog` searches catalog objects by name, catalog, constellation,
-  and optional coordinates (`--ra`/`--dec`, `--sort`, `--limit`).
+  and optional coordinates (`--ra`/`--dec`, `--radius`, `--sort`, `--limit`).
+- API: `GET /api/catalogs` lists installed catalogs with object counts (`sort=entries|name`).
+- API: `GET/POST /api/catalogs/list` supports coordinate proximity search (`ra`, `decl`,
+  `proximity`) and matches object `name` or `altname` when filtering by `name`.
 - API: `PATCH /api/projects/{project_id}/subframes/{subframe_id}` now updates only
   the columns supplied in the body. `count` and `goal_count` are no longer mirrored,
   so the runner can bump captured-frame counts without disturbing the user-defined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 
 ## Unreleased
 
+- CLI: `hevelius catalogs` lists installed catalogs with object counts (`--sort entries|name`).
+- CLI: `hevelius catalog` searches catalog objects by name, catalog, constellation,
+  and optional coordinates (`--ra`/`--dec`, `--sort`, `--limit`).
 - API: `PATCH /api/projects/{project_id}/subframes/{subframe_id}` now updates only
   the columns supplied in the body. `count` and `goal_count` are no longer mirrored,
   so the runner can bump captured-frame counts without disturbing the user-defined

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -884,6 +884,25 @@ components:
         version:
           type: string
           description: Catalog version
+    InstalledCatalog:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Catalog name
+        shortname:
+          type: string
+          description: Catalog short name
+        object_count:
+          type: integer
+          description: Number of objects loaded for this catalog
+    CatalogsInstalledList:
+      type: object
+      properties:
+        catalogs:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstalledCatalog'
     Object:
       type: object
       properties:
@@ -2650,6 +2669,28 @@ paths:
           description: Project or subframe not found
       security:
         - bearerAuth: []
+  /api/catalogs:
+    get:
+      summary: List installed catalogs
+      description: Returns catalogs loaded in the database with object counts per catalog
+      parameters:
+        - name: sort
+          in: query
+          description: Sort by object count (entries) or catalog name (name)
+          required: false
+          schema:
+            type: string
+            enum: [entries, name]
+            default: entries
+      responses:
+        '200':
+          description: Installed catalogs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogsInstalledList'
+      security:
+        - bearerAuth: []
   /api/catalogs/search:
     get:
       summary: Search for astronomical objects
@@ -2736,10 +2777,33 @@ paths:
             type: string
         - name: name
           in: query
-          description: Filter by object name
+          description: Filter by object name (partial match on name or altname)
           required: false
           schema:
             type: string
+        - name: ra
+          in: query
+          description: Right ascension in hours; requires decl
+          required: false
+          schema:
+            type: number
+            format: float
+        - name: decl
+          in: query
+          description: Declination in degrees; requires ra
+          required: false
+          schema:
+            type: number
+            format: float
+        - name: proximity
+          in: query
+          description: Search radius in degrees when ra and decl are set
+          required: false
+          schema:
+            type: number
+            format: float
+            default: 1.0
+            minimum: 0
       responses:
         '200':
           description: List of objects with pagination info
@@ -2747,6 +2811,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ObjectsList'
+        '422':
+          description: Invalid parameters (e.g. ra without decl)
       security:
         - bearerAuth: []
     post:
@@ -2788,7 +2854,21 @@ paths:
                   description: Filter by constellation code (e.g. Sgr)
                 name:
                   type: string
-                  description: Filter by object name
+                  description: Filter by object name (partial match on name or altname)
+                ra:
+                  type: number
+                  format: float
+                  description: Right ascension in hours; requires decl
+                decl:
+                  type: number
+                  format: float
+                  description: Declination in degrees; requires ra
+                proximity:
+                  type: number
+                  format: float
+                  description: Search radius in degrees when ra and decl are set
+                  default: 1.0
+                  minimum: 0
       responses:
         '200':
           description: List of objects with pagination info
@@ -2796,5 +2876,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ObjectsList'
+        '422':
+          description: Invalid parameters (e.g. ra without decl)
       security:
         - bearerAuth: []

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -133,6 +133,12 @@ def run():
         help="Declination (+DD MM [SS] format); requires --ra",
     )
     catalog_search_parser.add_argument(
+        '--radius',
+        type=float,
+        default=None,
+        help="Search radius in degrees with --ra and --dec (default: 1.0)",
+    )
+    catalog_search_parser.add_argument(
         '--sort',
         choices=['catalog', 'name', 'ra', 'decl', 'const', 'type', 'magn'],
         default='name',

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -15,6 +15,7 @@ from hevelius.cmd_stats import stats, histogram_show, groups
 from hevelius.cmd_db_migrate import migrate
 from hevelius.cmd_repo import repo
 from hevelius.cmd_catalog import catalog, format_get
+from hevelius.cmd_catalogs import list_catalogs, find_catalog_objects
 from hevelius.cmd_users import list_users, add_user, disable_user, enable_user, edit_user_profile
 from hevelius.cmd_equipment import (
     list_filters,
@@ -96,6 +97,59 @@ def run():
     catalog_parser.add_argument("--resy", help="filtering: y resolution (pixels)", type=int, default=0)
     catalog_parser.add_argument("--sensor", help="filtering: specifies sensor by its name (name in sensors table)", type=str, default="")
     catalog_parser.add_argument("--sensor-id", help="filtering: specifies sensor by its id (sensor_id in sensors table)", type=int, default=0)
+
+    catalogs_parser = subparsers.add_parser('catalogs', help="List installed astronomical catalogs")
+    catalogs_parser.add_argument(
+        '--sort',
+        choices=['entries', 'name'],
+        default='entries',
+        help="Sort by object count (entries, default) or catalog name (name)",
+    )
+
+    catalog_search_parser = subparsers.add_parser('catalog', help="Search astronomical catalog objects")
+    catalog_search_parser.add_argument(
+        'name',
+        nargs='?',
+        default=None,
+        help="Object name to search for (partial match on name or altname)",
+    )
+    catalog_search_parser.add_argument(
+        '--catalog',
+        dest='catalog',
+        metavar='SHORTNAME',
+        help="Filter by catalog short name (e.g. NGC, M, C)",
+    )
+    catalog_search_parser.add_argument(
+        '--const',
+        metavar='CODE',
+        help="Filter by constellation code (e.g. Cyg, Ori)",
+    )
+    catalog_search_parser.add_argument(
+        '-r', '--ra',
+        help="Right Ascension (HH MM [SS] format); requires --dec",
+    )
+    catalog_search_parser.add_argument(
+        '-d', '--dec',
+        help="Declination (+DD MM [SS] format); requires --ra",
+    )
+    catalog_search_parser.add_argument(
+        '--sort',
+        choices=['catalog', 'name', 'ra', 'decl', 'const', 'type', 'magn'],
+        default='name',
+        help="Sort results by field (default: name)",
+    )
+    catalog_search_parser.add_argument(
+        '--sort-order',
+        choices=['asc', 'desc'],
+        default='asc',
+        help="Sort order (default: asc)",
+    )
+    catalog_search_parser.add_argument(
+        '--limit',
+        type=int,
+        default=None,
+        help="Maximum number of objects to return",
+    )
 
     filters_parser = subparsers.add_parser('filters', help="List optical filters")
     filters_parser.add_argument('--active-only', action='store_true', help="Show only active filters")
@@ -307,6 +361,10 @@ def run():
         if args.data_command == "catalog":
             return catalog(args)  # see cmd_catalog.py
         return parser.print_help()
+    if args.command == "catalogs":
+        return list_catalogs(args)
+    if args.command == "catalog":
+        return find_catalog_objects(args)
     if args.command == "config":
         return config_show()  # see cmd_basic.py
     if args.command == "repo":

--- a/doc/catalogs.md
+++ b/doc/catalogs.md
@@ -25,19 +25,28 @@ Search catalog objects (all filters are optional; combine as needed):
 python bin/hevelius catalog M31
 python bin/hevelius catalog --catalog NGC --const Cyg
 python bin/hevelius catalog 7000 --catalog NGC
-python bin/hevelius catalog --ra "0 42 44" --dec "+41 16 09" --limit 5
+python bin/hevelius catalog --ra "0 42 44" --dec "+41 16 09" --radius 2.0 --limit 5
 ```
 
 - Positional `name` — partial match on `name` or `altname`.
 - `--catalog` — catalog short name (e.g. `NGC`, `M`, `C`).
 - `--const` — constellation code (e.g. `Cyg`, `Ori`).
-- `--ra` / `--dec` — coordinates (both required together); objects within 1° are returned.
+- `--ra` / `--dec` — coordinates (both required together).
+- `--radius` — search radius in degrees with `--ra` and `--dec` (default: 1.0).
 - `--sort` — `catalog`, `name`, `ra`, `decl`, `const`, `type`, or `magn` (default: `name`).
 - `--sort-order` — `asc` or `desc` (default: `asc`).
 - `--limit` — cap the number of rows returned.
 
-The REST API exposes similar search under `/api/catalogs/search` and
-`/api/catalogs/list` (see `api/openapi.yaml`).
+The REST API exposes the same capabilities (JWT required):
+
+- `GET /api/catalogs` — installed catalogs with object counts (`sort=entries|name`)
+- `GET /api/catalogs/list` — search/filter objects with pagination; supports
+  `catalog`, `constellation`, `name` (name or altname), `ra`, `decl`, `proximity`,
+  `sort_by`, `sort_order`, `page`, `per_page`
+- `POST /api/catalogs/list` — same filters in JSON body
+- `GET /api/catalogs/search` — quick name/altname search by `query` and `limit`
+
+See `api/openapi.yaml` for request/response schemas.
 
 ## Installing catalog data
 

--- a/doc/catalogs.md
+++ b/doc/catalogs.md
@@ -4,16 +4,46 @@ Hevelius comes with several astronomical catalogs. Their use is not mandatory.
 You may live without them just fine, but you'll need to use RA/DEC coordinates
 all the time.
 
-Currently there are 4 catalogs available:
+Catalog data files live in the `catalogs/` directory (see `catalogs/README.md`
+for the full list). Common catalogs include NGC, IC, Messier (M), Caldwell (C),
+Barnard (B), Sharpless (Sh2), Lynds bright/dark nebulae (LBN, LDN), and others.
 
-- NGC
-- IC
-- Messier
-- Caldwell
+## CLI
 
-They're stored in `catalogs/` directory and are in `.psql` format. To install
-them, run your `psql -U hevelius` client and then use `\i catalogs/filename`
-command. For example, to install Messier catalog:
+List catalogs installed in the database (with object counts):
+
+```bash
+python bin/hevelius catalogs
+python bin/hevelius catalogs --sort name
+```
+
+`--sort` may be `entries` (default, by number of objects) or `name`.
+
+Search catalog objects (all filters are optional; combine as needed):
+
+```bash
+python bin/hevelius catalog M31
+python bin/hevelius catalog --catalog NGC --const Cyg
+python bin/hevelius catalog 7000 --catalog NGC
+python bin/hevelius catalog --ra "0 42 44" --dec "+41 16 09" --limit 5
+```
+
+- Positional `name` — partial match on `name` or `altname`.
+- `--catalog` — catalog short name (e.g. `NGC`, `M`, `C`).
+- `--const` — constellation code (e.g. `Cyg`, `Ori`).
+- `--ra` / `--dec` — coordinates (both required together); objects within 1° are returned.
+- `--sort` — `catalog`, `name`, `ra`, `decl`, `const`, `type`, or `magn` (default: `name`).
+- `--sort-order` — `asc` or `desc` (default: `asc`).
+- `--limit` — cap the number of rows returned.
+
+The REST API exposes similar search under `/api/catalogs/search` and
+`/api/catalogs/list` (see `api/openapi.yaml`).
+
+## Installing catalog data
+
+Files are in `.psql` format. To install them, run your `psql -U hevelius`
+client and then use `\i catalogs/filename`. For example, to install the
+Messier catalog:
 
 ```shell
 $ psql -U hevelius

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -57,8 +57,8 @@ User add / enable / disable actions are recorded in the **user_admin_audit** tab
 - **catalogs** – List catalogs loaded in the database with object counts.
   `hevelius catalogs [--sort entries|name]` (default sort: by object count).
 - **catalog** – Search catalog objects: `hevelius catalog [NAME] [--catalog SHORTNAME]
-  [--const CODE] [--ra HH MM SS] [--dec +DD MM SS] [--sort FIELD] [--sort-order asc|desc]
-  [--limit N]`. See `doc/catalogs.md` for details.
+  [--const CODE] [--ra HH MM SS] [--dec +DD MM SS] [--radius DEG] [--sort FIELD]
+  [--sort-order asc|desc] [--limit N]`. See `doc/catalogs.md` for details.
 
 ### Data catalog – objects near coordinates and matching frames
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -9,13 +9,15 @@ $ python bin/hevelius
 Hevelius
 
 usage: hevelius [-h]
-  {db,config,version,data,repo,filters,filter,sensors,sensor,projects,project,telescopes,telescope,users,user} ...
+  {db,config,version,data,repo,catalogs,catalog,filters,filter,sensors,sensor,projects,project,telescopes,telescope,users,user} ...
 
 positional arguments:
   db                    Manages database (version, migrate, backup, stats)
   config                Shows current Hevelius (DB, file repository) configuration
   version               Shows the current Hevelius package version
   data                  Data mining (distrib, groups, catalog)
+  catalogs              List installed astronomical catalogs
+  catalog               Search astronomical catalog objects
   repo                  Manages files repository on local storage
   filters               List optical filters
   filter                Add or edit a filter
@@ -50,28 +52,33 @@ User add / enable / disable actions are recorded in the **user_admin_audit** tab
 - **db backup** – Database backup.
 - **db stats** – Database statistics.
 
-### Catalog - searching for catalog objects and associated frames
+### Catalogs – list and search astronomical objects
 
-There are two ways how objects can be located. First is by using a name from the
-catalog: `--object M1`. If the object is found, its coordinates are then used.
-The alternative way is to specify the coordinates directly:
-`--ra "11 22 33" --decl "-22 33 44"`. In both cases, you can specify the radius
-around the specified object: `--proximity 2.0`. The default being 1 degree.
+- **catalogs** – List catalogs loaded in the database with object counts.
+  `hevelius catalogs [--sort entries|name]` (default sort: by object count).
+- **catalog** – Search catalog objects: `hevelius catalog [NAME] [--catalog SHORTNAME]
+  [--const CODE] [--ra HH MM SS] [--dec +DD MM SS] [--sort FIELD] [--sort-order asc|desc]
+  [--limit N]`. See `doc/catalogs.md` for details.
 
-Hevelius will find catalog objects for you and also list frames that are in the
-database. You can use `--format XXX` to specify the output format. See `--help`
-for details as the formats are being updated frequently. As of time of writing
-this text, the following formats were supported: `none`, `filenames`, `csv`,
-`brief`, `full`, `pixinsight`.
+### Data catalog – objects near coordinates and matching frames
 
-The `pixinsight` format is intended to be used with PixInsight's
-SubframeSelector. To import the list, open PixInsight, menu Process ->
-ImageInspection -> SubframeSelector, then click on the `edit instance source code`
-(square icon at the bottom), then paste the content into `P.subframes`.
+The **data catalog** subcommand finds catalog objects and observation frames near
+a sky position. There are two ways to specify the position. First, use a catalog
+name: `--object M1`. If the object is found, its coordinates are used. Alternatively,
+specify coordinates directly: `--ra "11 22 33" --decl "-22 33 44"`. In both cases,
+set the search radius with `--proximity 2.0` (default 1 degree).
 
-An example command line call:
+Hevelius lists nearby catalog objects and frames in the database. Use
+`--format XXX` for output: `none`, `filenames`, `csv`, `brief`, `full`, `pixinsight`.
 
-```python bin/hevelius catalog --object C38 --proximity 0.5 --format full```
+The `pixinsight` format is for PixInsight SubframeSelector (Process → ImageInspection
+→ SubframeSelector → edit instance source code → paste into `P.subframes`).
+
+Example:
+
+```bash
+python bin/hevelius data catalog --object C38 --proximity 0.5 --format full
+```
 
 ### Filters, sensors, and projects (schema 15+)
 

--- a/hevelius/cmd_catalogs.py
+++ b/hevelius/cmd_catalogs.py
@@ -1,0 +1,192 @@
+"""
+CLI commands for listing installed catalogs and searching catalog objects.
+"""
+
+import sys
+from typing import Any, Dict, List, Optional
+
+from hevelius import db
+from hevelius.utils import format_dec, format_ra, parse_dec, parse_ra
+
+CATALOGS_SORT_CHOICES = ("entries", "name")
+OBJECT_SORT_CHOICES = ("catalog", "name", "ra", "decl", "const", "type", "magn")
+
+
+def _catalog_row_to_dict(row) -> Dict[str, Any]:
+    return {
+        "name": row[0],
+        "shortname": row[1],
+        "object_count": row[2],
+    }
+
+
+def _object_row_to_dict(row) -> Dict[str, Any]:
+    return {
+        "object_id": row[0],
+        "name": row[1],
+        "ra": row[2],
+        "decl": row[3],
+        "descr": row[4],
+        "comment": row[5],
+        "type": row[6],
+        "epoch": row[7],
+        "const": row[8],
+        "magn": row[9],
+        "x": row[10],
+        "y": row[11],
+        "altname": row[12],
+        "distance": row[13],
+        "catalog": row[14],
+    }
+
+
+def fetch_installed_catalogs(sort_by: str = "entries", sort_order: str = "desc") -> List[Dict[str, Any]]:
+    """Return installed catalogs as a list of dicts."""
+    cnx = db.connect()
+    rows = db.catalogs_installed_list(cnx, sort_by=sort_by, sort_order=sort_order)
+    cnx.close()
+    return [_catalog_row_to_dict(row) for row in rows]
+
+
+def fetch_catalog_objects(
+    catalog: Optional[str] = None,
+    constellation: Optional[str] = None,
+    name: Optional[str] = None,
+    ra_hours: Optional[float] = None,
+    decl: Optional[float] = None,
+    proximity: float = 1.0,
+    sort_by: str = "name",
+    sort_order: str = "asc",
+    limit: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return matching catalog objects as a list of dicts."""
+    cnx = db.connect()
+    rows = db.catalog_objects_search(
+        cnx,
+        catalog=catalog,
+        constellation=constellation,
+        name=name,
+        ra_hours=ra_hours,
+        decl=decl,
+        proximity=proximity,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+    )
+    cnx.close()
+    return [_object_row_to_dict(row) for row in rows]
+
+
+def render_catalogs_text(catalogs: List[Dict[str, Any]]) -> str:
+    """Format catalog list as plain text."""
+    if not catalogs:
+        return "No catalogs found."
+
+    lines = [
+        f"{'Short':<8} {'Objects':>8}  Name",
+        "-" * 72,
+    ]
+    for entry in catalogs:
+        lines.append(
+            f"{entry['shortname']:<8} {entry['object_count']:>8}  {entry['name']}"
+        )
+    return "\n".join(lines)
+
+
+def render_objects_text(objects: List[Dict[str, Any]]) -> str:
+    """Format catalog object search results as plain text."""
+    if not objects:
+        return "No objects found."
+
+    lines = [
+        f"{'Name':<12} {'Catalog':<6} {'Type':<4} {'Const':<4} {'Mag':>6}  "
+        f"{'RA':<12} {'Dec':<12}  Description",
+        "-" * 96,
+    ]
+    for obj in objects:
+        magn = "" if obj["magn"] is None else f"{obj['magn']:6.1f}"
+        ra_str = format_ra(obj["ra"]) if obj["ra"] is not None else ""
+        dec_str = format_dec(obj["decl"]) if obj["decl"] is not None else ""
+        descr = (obj["descr"] or "")[:40]
+        altname = obj["altname"]
+        name = obj["name"]
+        if altname:
+            name = f"{name}/{altname}"
+        lines.append(
+            f"{name[:12]:<12} {obj['catalog']:<6} {(obj['type'] or ''):<4} "
+            f"{(obj['const'] or ''):<4} {magn:>6}  {ra_str:<12} {dec_str:<12}  {descr}"
+        )
+    return "\n".join(lines)
+
+
+def _validate_ra_dec_pair(ra_value, dec_value) -> Optional[tuple]:
+    """Return (ra_hours, decl) or print an error and exit."""
+    has_ra = ra_value is not None
+    has_dec = dec_value is not None
+    if has_ra != has_dec:
+        print("Error: specify both --ra and --dec, or neither.", file=sys.stderr)
+        sys.exit(1)
+    if not has_ra:
+        return None
+    try:
+        return parse_ra(ra_value), parse_dec(dec_value)
+    except (ValueError, TypeError) as exc:
+        print(f"Error: invalid coordinates: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def list_catalogs(args) -> int:
+    """CLI handler for 'hevelius catalogs'."""
+    sort_by = getattr(args, "sort", "entries") or "entries"
+    if sort_by not in CATALOGS_SORT_CHOICES:
+        print(f"Error: invalid --sort value '{sort_by}'. Use 'entries' or 'name'.", file=sys.stderr)
+        return 1
+
+    sort_order = "desc" if sort_by == "entries" else "asc"
+    catalogs = fetch_installed_catalogs(sort_by=sort_by, sort_order=sort_order)
+    print(render_catalogs_text(catalogs))
+    return 0
+
+
+def find_catalog_objects(args) -> int:
+    """CLI handler for 'hevelius catalog'."""
+    coords = _validate_ra_dec_pair(getattr(args, "ra", None), getattr(args, "dec", None))
+
+    sort_by = getattr(args, "sort", "name") or "name"
+    if sort_by not in OBJECT_SORT_CHOICES:
+        print(
+            f"Error: invalid --sort value '{sort_by}'. "
+            f"Use one of: {', '.join(OBJECT_SORT_CHOICES)}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    sort_order = getattr(args, "sort_order", "asc") or "asc"
+    if sort_order not in ("asc", "desc"):
+        print("Error: invalid --sort-order. Use 'asc' or 'desc'.", file=sys.stderr)
+        return 1
+
+    name = getattr(args, "name", None)
+    if name is not None and not str(name).strip():
+        name = None
+
+    limit = getattr(args, "limit", None)
+    if limit is not None and limit < 1:
+        print("Error: --limit must be a positive integer.", file=sys.stderr)
+        return 1
+
+    ra_hours = coords[0] if coords else None
+    decl = coords[1] if coords else None
+
+    objects = fetch_catalog_objects(
+        catalog=getattr(args, "catalog", None),
+        constellation=getattr(args, "const", None),
+        name=name,
+        ra_hours=ra_hours,
+        decl=decl,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+    )
+    print(render_objects_text(objects))
+    return 0

--- a/hevelius/cmd_catalogs.py
+++ b/hevelius/cmd_catalogs.py
@@ -178,12 +178,25 @@ def find_catalog_objects(args) -> int:
     ra_hours = coords[0] if coords else None
     decl = coords[1] if coords else None
 
+    radius = getattr(args, "radius", None)
+    if coords:
+        proximity = radius if radius is not None else 1.0
+        if proximity <= 0:
+            print("Error: --radius must be a positive number.", file=sys.stderr)
+            return 1
+    elif radius is not None:
+        print("Error: --radius requires --ra and --dec.", file=sys.stderr)
+        return 1
+    else:
+        proximity = 1.0
+
     objects = fetch_catalog_objects(
         catalog=getattr(args, "catalog", None),
         constellation=getattr(args, "const", None),
         name=name,
         ra_hours=ra_hours,
         decl=decl,
+        proximity=proximity,
         sort_by=sort_by,
         sort_order=sort_order,
         limit=limit,

--- a/hevelius/db.py
+++ b/hevelius/db.py
@@ -358,29 +358,20 @@ def catalogs_installed_list(conn, sort_by: str = "entries", sort_order: str = "d
     return run_query(conn, query)
 
 
-def catalog_objects_search(
-    conn,
+def catalog_objects_build_where(
     catalog: str = None,
     constellation: str = None,
     name: str = None,
     ra_hours: float = None,
     decl: float = None,
     proximity: float = 1.0,
-    sort_by: str = "name",
-    sort_order: str = "asc",
-    limit: int = None,
-) -> List:
+):
     """
-    Search catalog objects with optional filters.
+    Build WHERE clause and parameters for catalog object queries.
 
+    Returns (where_suffix, params) where where_suffix is '' or ' WHERE ...'.
     RA is in hours (matching objects.ra storage). Declination is in degrees.
-    When ra_hours and decl are both set, objects within proximity degrees are returned.
     """
-    if sort_by not in CATALOG_OBJECT_SORT_FIELDS:
-        sort_by = "name"
-    if sort_order not in ("asc", "desc"):
-        sort_order = "asc"
-
     where_clauses = []
     params = []
 
@@ -408,14 +399,74 @@ def catalog_objects_search(
         )
         params.extend([decl, decl, ra_deg, proximity])
 
-    query = _OBJECT_SELECT
     if where_clauses:
-        query += " WHERE " + " AND ".join(where_clauses)
+        return " WHERE " + " AND ".join(where_clauses), params
+    return "", []
 
+
+def catalog_objects_count(
+    conn,
+    catalog: str = None,
+    constellation: str = None,
+    name: str = None,
+    ra_hours: float = None,
+    decl: float = None,
+    proximity: float = 1.0,
+) -> int:
+    """Return count of objects matching the given filters."""
+    where, params = catalog_objects_build_where(
+        catalog=catalog,
+        constellation=constellation,
+        name=name,
+        ra_hours=ra_hours,
+        decl=decl,
+        proximity=proximity,
+    )
+    query = "SELECT COUNT(*) FROM objects" + where
+    return run_query(conn, query, tuple(params) if params else None)[0][0]
+
+
+def catalog_objects_search(
+    conn,
+    catalog: str = None,
+    constellation: str = None,
+    name: str = None,
+    ra_hours: float = None,
+    decl: float = None,
+    proximity: float = 1.0,
+    sort_by: str = "name",
+    sort_order: str = "asc",
+    limit: int = None,
+    offset: int = None,
+) -> List:
+    """
+    Search catalog objects with optional filters.
+
+    RA is in hours (matching objects.ra storage). Declination is in degrees.
+    When ra_hours and decl are both set, objects within proximity degrees are returned.
+    """
+    if sort_by not in CATALOG_OBJECT_SORT_FIELDS:
+        sort_by = "name"
+    if sort_order not in ("asc", "desc"):
+        sort_order = "asc"
+
+    where, params = catalog_objects_build_where(
+        catalog=catalog,
+        constellation=constellation,
+        name=name,
+        ra_hours=ra_hours,
+        decl=decl,
+        proximity=proximity,
+    )
+
+    query = _OBJECT_SELECT + where
     query += f" ORDER BY {sort_by} {sort_order.upper()}"
     if limit is not None:
         query += " LIMIT %s"
         params.append(limit)
+    if offset is not None:
+        query += " OFFSET %s"
+        params.append(offset)
 
     return run_query(conn, query, tuple(params) if params else None)
 

--- a/hevelius/db.py
+++ b/hevelius/db.py
@@ -321,6 +321,105 @@ def catalog_get(conn, name: str) -> List:
     return result
 
 
+CATALOG_LIST_SORT_FIELDS = {"name", "entries"}
+CATALOG_OBJECT_SORT_FIELDS = {"catalog", "name", "ra", "decl", "const", "type", "magn"}
+
+_OBJECT_SELECT = """
+    SELECT object_id, name, ra, decl, descr, comment, type, epoch, const,
+           magn, x, y, altname, distance, catalog
+    FROM objects
+"""
+
+
+def catalogs_installed_list(conn, sort_by: str = "entries", sort_order: str = "desc") -> List:
+    """
+    Returns installed catalogs with object counts.
+
+    Each row is (name, shortname, object_count).
+    sort_by: 'entries' (object count) or 'name'.
+    """
+    if sort_by not in CATALOG_LIST_SORT_FIELDS:
+        sort_by = "entries"
+    if sort_order not in ("asc", "desc"):
+        sort_order = "desc"
+
+    if sort_by == "name":
+        order = f"c.name {sort_order.upper()}"
+    else:
+        order = f"object_count {sort_order.upper()}, c.name ASC"
+
+    query = f"""
+        SELECT LEFT(c.name, 64) AS name, c.shortname, COUNT(o.*) AS object_count
+        FROM catalogs c
+        LEFT JOIN objects o ON c.shortname = o.catalog
+        GROUP BY c.name, c.shortname
+        ORDER BY {order}
+    """
+    return run_query(conn, query)
+
+
+def catalog_objects_search(
+    conn,
+    catalog: str = None,
+    constellation: str = None,
+    name: str = None,
+    ra_hours: float = None,
+    decl: float = None,
+    proximity: float = 1.0,
+    sort_by: str = "name",
+    sort_order: str = "asc",
+    limit: int = None,
+) -> List:
+    """
+    Search catalog objects with optional filters.
+
+    RA is in hours (matching objects.ra storage). Declination is in degrees.
+    When ra_hours and decl are both set, objects within proximity degrees are returned.
+    """
+    if sort_by not in CATALOG_OBJECT_SORT_FIELDS:
+        sort_by = "name"
+    if sort_order not in ("asc", "desc"):
+        sort_order = "asc"
+
+    where_clauses = []
+    params = []
+
+    if catalog:
+        where_clauses.append("catalog ILIKE %s")
+        params.append(catalog)
+
+    if constellation:
+        where_clauses.append("const ILIKE %s")
+        params.append(constellation)
+
+    if name:
+        pattern = f"%{name}%"
+        where_clauses.append("(name ILIKE %s OR altname ILIKE %s)")
+        params.extend([pattern, pattern])
+
+    if ra_hours is not None and decl is not None:
+        ra_deg = ra_hours * 15.0
+        where_clauses.append(
+            "degrees(2 * asin(sqrt("
+            "pow(sin(radians(decl - %s) / 2), 2) + "
+            "cos(radians(%s)) * cos(radians(decl)) * "
+            "pow(sin(radians(ra*15 - %s) / 2), 2)"
+            "))) < %s"
+        )
+        params.extend([decl, decl, ra_deg, proximity])
+
+    query = _OBJECT_SELECT
+    if where_clauses:
+        query += " WHERE " + " AND ".join(where_clauses)
+
+    query += f" ORDER BY {sort_by} {sort_order.upper()}"
+    if limit is not None:
+        query += " LIMIT %s"
+        params.append(limit)
+
+    return run_query(conn, query, tuple(params) if params else None)
+
+
 def tasks_radius_get(conn, ra: float, decl: float, radius: float, filter: str = "", order: str = "") -> List:
     """
     Returns frames (completed tasks) that are close (within radius degrees) to

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -801,6 +801,72 @@ class StatusMsgSchema(Schema):
     msg = fields.String()
 
 
+class TaskGetQuerySchema(Schema):
+    task_id = fields.Integer(required=True)
+
+
+class ScopesListQuerySchema(Schema):
+    sort_by = fields.String(load_default="scope_id")
+    sort_order = fields.String(load_default="asc")
+
+
+class ScopeCreateResponseSchema(Schema):
+    status = fields.Boolean()
+    scope_id = fields.Integer()
+    scope = fields.Nested(TelescopeSchema)
+    msg = fields.String()
+
+
+class ScopeDetailResponseSchema(Schema):
+    status = fields.Boolean()
+    scope = fields.Nested(TelescopeSchema)
+    msg = fields.String()
+
+
+class ScopeFilterIdBodySchema(Schema):
+    filter_id = fields.Integer(required=True)
+
+
+class FiltersListResponseSchema(Schema):
+    filters = fields.List(fields.Nested(FilterSchema))
+
+
+class FilterCreateResponseSchema(Schema):
+    status = fields.Boolean()
+    filter_id = fields.Integer()
+    filter = fields.Nested(FilterSchema)
+    msg = fields.String()
+
+
+class FilterDetailResponseSchema(Schema):
+    status = fields.Boolean()
+    filter = fields.Nested(FilterSchema)
+    msg = fields.String()
+
+
+class SensorsListResponseSchema(Schema):
+    sensors = fields.List(fields.Nested(SensorSchema))
+
+
+class SensorCreateResponseSchema(Schema):
+    status = fields.Boolean()
+    sensor_id = fields.Integer()
+    sensor = fields.Nested(SensorSchema)
+    msg = fields.String()
+
+
+class SensorDetailResponseSchema(Schema):
+    status = fields.Boolean()
+    sensor = fields.Nested(SensorSchema)
+    msg = fields.String()
+
+
+class ProjectDetailResponseSchema(Schema):
+    status = fields.Boolean()
+    project = fields.Nested(ProjectSchema)
+    msg = fields.String()
+
+
 class PasswordResetTokenIssueResponseSchema(Schema):
     status = fields.Boolean()
     token = fields.String(metadata={"description": "Plain token; shown only once"})
@@ -1665,7 +1731,7 @@ class VersionResource(MethodView):
 @blp.route("/task-get")
 class TaskGetResource(MethodView):
     @jwt_required()
-    @blp.arguments(Schema.from_dict({"task_id": fields.Integer(required=True)}), location="query")
+    @blp.arguments(TaskGetQuerySchema, location="query")
     @blp.response(200, TaskGetResponseSchema)
     def get(self, args):
         """Get single task details
@@ -1956,10 +2022,7 @@ def _fetch_filters_for_scopes(cnx, scope_ids):
 @blp.route("/scopes")
 class ScopesResource(MethodView):
     @jwt_required()
-    @blp.arguments(Schema.from_dict({
-        "sort_by": fields.String(load_default="scope_id"),
-        "sort_order": fields.String(load_default="asc")
-    }), location="query")
+    @blp.arguments(ScopesListQuerySchema, location="query")
     @blp.response(200, TelescopesListSchema)
     def get(self, args):
         """Get list of telescopes with their associated sensors and filters. Supports sorting."""
@@ -1981,12 +2044,7 @@ class ScopesResource(MethodView):
 
     @jwt_required()
     @blp.arguments(ScopeCreateSchema)
-    @blp.response(200, Schema.from_dict({
-        "status": fields.Boolean(),
-        "scope_id": fields.Integer(),
-        "scope": fields.Nested(TelescopeSchema),
-        "msg": fields.String()
-    }))
+    @blp.response(200, ScopeCreateResponseSchema)
     def post(self, data):
         """Add new telescope. name required; scope_id optional (auto-assigned if omitted)."""
         name = data["name"]
@@ -2033,7 +2091,7 @@ class ScopesResource(MethodView):
 @blp.route("/scopes/<int:scope_id>")
 class ScopeDetailResource(MethodView):
     @jwt_required()
-    @blp.response(200, Schema.from_dict({"status": fields.Boolean(), "scope": fields.Nested(TelescopeSchema), "msg": fields.String()}))
+    @blp.response(200, ScopeDetailResponseSchema)
     def get(self, scope_id):
         """Get telescope details with sensor and filters."""
         cnx = db.connect()
@@ -2048,7 +2106,7 @@ class ScopeDetailResource(MethodView):
 
     @jwt_required()
     @blp.arguments(ScopeUpdateSchema)
-    @blp.response(200, Schema.from_dict({"status": fields.Boolean(), "scope": fields.Nested(TelescopeSchema), "msg": fields.String()}))
+    @blp.response(200, ScopeDetailResponseSchema)
     def patch(self, data, scope_id):
         """Edit telescope. Use sensor_id 0 to remove sensor."""
         cnx = db.connect()
@@ -2079,8 +2137,8 @@ class ScopeDetailResource(MethodView):
 @blp.route("/scopes/<int:scope_id>/filters")
 class ScopeFiltersResource(MethodView):
     @jwt_required()
-    @blp.arguments(Schema.from_dict({"filter_id": fields.Integer(required=True)}))
-    @blp.response(200, Schema.from_dict({"status": fields.Boolean(), "msg": fields.String()}))
+    @blp.arguments(ScopeFilterIdBodySchema)
+    @blp.response(200, StatusMsgSchema)
     def post(self, data, scope_id):
         """Add filter to telescope."""
         filter_id = data["filter_id"]
@@ -2102,7 +2160,7 @@ class ScopeFiltersResource(MethodView):
 @blp.route("/scopes/<int:scope_id>/filters/<int:filter_id>")
 class ScopeFilterRemoveResource(MethodView):
     @jwt_required()
-    @blp.response(200, Schema.from_dict({"status": fields.Boolean(), "msg": fields.String()}))
+    @blp.response(200, StatusMsgSchema)
     def delete(self, scope_id, filter_id):
         """Remove filter from telescope."""
         cnx = db.connect()
@@ -2146,7 +2204,7 @@ def _telescope_row_to_dict(row, filters_list=None):
 @blp.route("/filters")
 class FiltersResource(MethodView):
     @jwt_required()
-    @blp.response(200, Schema.from_dict({"filters": fields.List(fields.Nested(FilterSchema))}))
+    @blp.response(200, FiltersListResponseSchema)
     def get(self):
         """Get list of filters. Sortable by filter_id, short_name, full_name, active (default filter_id)."""
         active = request.args.get("active", type=lambda v: v.lower() == "true" if isinstance(v, str) else None)
@@ -2170,12 +2228,7 @@ class FiltersResource(MethodView):
 
     @jwt_required()
     @blp.arguments(FilterCreateSchema)
-    @blp.response(200, Schema.from_dict({
-        "status": fields.Boolean(),
-        "filter_id": fields.Integer(),
-        "filter": fields.Nested(FilterSchema),
-        "msg": fields.String()
-    }))
+    @blp.response(200, FilterCreateResponseSchema)
     def post(self, filter_data):
         """Add new filter"""
         short_name = filter_data["short_name"]
@@ -2216,11 +2269,7 @@ class FiltersResource(MethodView):
 @blp.route("/filters/<int:filter_id>")
 class FilterDetailResource(MethodView):
     @jwt_required()
-    @blp.response(200, Schema.from_dict({
-        "status": fields.Boolean(),
-        "filter": fields.Nested(FilterSchema),
-        "msg": fields.String()
-    }))
+    @blp.response(200, FilterDetailResponseSchema)
     def get(self, filter_id):
         """Get single filter"""
         cnx = db.connect()
@@ -2232,11 +2281,7 @@ class FilterDetailResource(MethodView):
 
     @jwt_required()
     @blp.arguments(FilterUpdateSchema)
-    @blp.response(200, Schema.from_dict({
-        "status": fields.Boolean(),
-        "filter": fields.Nested(FilterSchema),
-        "msg": fields.String()
-    }))
+    @blp.response(200, FilterDetailResponseSchema)
     def patch(self, filter_data, filter_id):
         """Edit filter (partial update). Set active true/false to activate or deactivate."""
         cnx = db.connect()
@@ -2287,7 +2332,7 @@ def _row_to_sensor(r):
 @blp.route("/sensors")
 class SensorsResource(MethodView):
     @jwt_required()
-    @blp.response(200, Schema.from_dict({"sensors": fields.List(fields.Nested(SensorSchema))}))
+    @blp.response(200, SensorsListResponseSchema)
     def get(self):
         """Get list of sensors (cameras) with optional sorting"""
         active = request.args.get("active", type=lambda v: v.lower() == "true" if isinstance(v, str) else None)
@@ -2312,12 +2357,7 @@ class SensorsResource(MethodView):
 
     @jwt_required()
     @blp.arguments(SensorCreateSchema)
-    @blp.response(200, Schema.from_dict({
-        "status": fields.Boolean(),
-        "sensor_id": fields.Integer(),
-        "sensor": fields.Nested(SensorSchema),
-        "msg": fields.String()
-    }))
+    @blp.response(200, SensorCreateResponseSchema)
     def post(self, sensor_data):
         """Add new sensor. width/height computed from resx*px/1000 if not provided. bits defaults to 0."""
         name = sensor_data["name"]
@@ -2376,11 +2416,7 @@ class SensorsResource(MethodView):
 @blp.route("/sensors/<int:sensor_id>")
 class SensorDetailResource(MethodView):
     @jwt_required()
-    @blp.response(200, Schema.from_dict({
-        "status": fields.Boolean(),
-        "sensor": fields.Nested(SensorSchema),
-        "msg": fields.String()
-    }))
+    @blp.response(200, SensorDetailResponseSchema)
     def get(self, sensor_id):
         """Get single sensor"""
         cnx = db.connect()
@@ -2393,11 +2429,7 @@ class SensorDetailResource(MethodView):
 
     @jwt_required()
     @blp.arguments(SensorUpdateSchema)
-    @blp.response(200, Schema.from_dict({
-        "status": fields.Boolean(),
-        "sensor": fields.Nested(SensorSchema),
-        "msg": fields.String()
-    }))
+    @blp.response(200, SensorDetailResponseSchema)
     def patch(self, sensor_data, sensor_id):
         """Edit sensor (partial update)"""
         cnx = db.connect()
@@ -2652,7 +2684,7 @@ class ProjectsResource(MethodView):
 @blp.route("/projects/<int:project_id>")
 class ProjectDetailResource(MethodView):
     @jwt_required()
-    @blp.response(200, Schema.from_dict({"status": fields.Boolean(), "project": fields.Nested(ProjectSchema), "msg": fields.String()}))
+    @blp.response(200, ProjectDetailResponseSchema)
     def get(self, project_id):
         """Get single project with subframes and user IDs"""
         cnx = db.connect()

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -698,6 +698,24 @@ class CatalogSchema(Schema):
     version = fields.String(metadata={"description": "Catalog version"})
 
 
+class InstalledCatalogSchema(Schema):
+    name = fields.String(required=True, metadata={"description": "Catalog name"})
+    shortname = fields.String(required=True, metadata={"description": "Catalog short name"})
+    object_count = fields.Integer(required=True, metadata={"description": "Number of objects in this catalog"})
+
+
+class CatalogsInstalledRequestSchema(Schema):
+    sort = fields.String(
+        missing='entries',
+        validate=validate.OneOf(['entries', 'name']),
+        metadata={"description": "Sort by object count (entries) or catalog name (name)"},
+    )
+
+
+class CatalogsInstalledResponseSchema(Schema):
+    catalogs = fields.List(fields.Nested(InstalledCatalogSchema))
+
+
 class ObjectSchema(Schema):
     object_id = fields.Integer(metadata={"description": "Object ID"})
     name = fields.String(required=True, metadata={"description": "Object name"})
@@ -740,7 +758,21 @@ class ObjectsListRequestSchema(Schema):
     # Filtering parameters
     catalog = fields.String(metadata={"description": "Filter by catalog short name"})
     constellation = fields.String(metadata={"description": "Filter by constellation code (e.g. Sgr)"})
-    name = fields.String(metadata={"description": "Filter by object name"})
+    name = fields.String(metadata={"description": "Filter by object name (matches name or altname)"})
+    ra = fields.Float(metadata={"description": "Right ascension in hours; requires decl"})
+    decl = fields.Float(metadata={"description": "Declination in degrees; requires ra"})
+    proximity = fields.Float(
+        missing=1.0,
+        validate=validate.Range(min=0.0),
+        metadata={"description": "Search radius in degrees when ra and decl are set"},
+    )
+
+    @validates_schema
+    def validate_ra_decl_pair(self, data, **_kwargs):
+        has_ra = data.get('ra') is not None
+        has_decl = data.get('decl') is not None
+        if has_ra != has_decl:
+            raise ValidationError('ra and decl must both be specified or both omitted')
 
 
 class ObjectsListResponseSchema(Schema):
@@ -2885,6 +2917,46 @@ class ProjectTaskResource(MethodView):
         return {"status": True, "msg": f"Task {task_id} removed from project {project_id}"}
 
 
+def _object_row_to_dict(row):
+    return {
+        'object_id': row[0],
+        'name': row[1],
+        'ra': row[2],
+        'decl': row[3],
+        'descr': row[4],
+        'comment': row[5],
+        'type': row[6],
+        'epoch': row[7],
+        'const': row[8],
+        'magn': row[9],
+        'x': row[10],
+        'y': row[11],
+        'altname': row[12],
+        'distance': row[13],
+        'catalog': row[14],
+    }
+
+
+@blp.route("/catalogs")
+class CatalogsInstalledResource(MethodView):
+    @jwt_required()
+    @blp.arguments(CatalogsInstalledRequestSchema, location="query")
+    @blp.response(200, CatalogsInstalledResponseSchema)
+    def get(self, args):
+        """List installed catalogs with object counts."""
+        sort_by = args.get('sort', 'entries')
+        sort_order = 'desc' if sort_by == 'entries' else 'asc'
+        cnx = db.connect()
+        rows = db.catalogs_installed_list(cnx, sort_by=sort_by, sort_order=sort_order)
+        cnx.close()
+        return {
+            'catalogs': [
+                {'name': row[0], 'shortname': row[1], 'object_count': row[2]}
+                for row in rows
+            ],
+        }
+
+
 @blp.route("/catalogs/search")
 class ObjectSearchResource(MethodView):
     @jwt_required()
@@ -2914,29 +2986,7 @@ class ObjectSearchResource(MethodView):
         results = db.run_query(cnx, search_query, (search_pattern, search_pattern, limit))
         cnx.close()
 
-        # Format the results
-        objects = []
-        for row in results:
-            obj = {
-                'object_id': row[0],
-                'name': row[1],
-                'ra': row[2],
-                'decl': row[3],
-                'descr': row[4],
-                'comment': row[5],
-                'type': row[6],
-                'epoch': row[7],
-                'const': row[8],
-                'magn': row[9],
-                'x': row[10],
-                'y': row[11],
-                'altname': row[12],
-                'distance': row[13],
-                'catalog': row[14]
-            }
-            objects.append(obj)
-
-        return {"objects": objects}
+        return {"objects": [_object_row_to_dict(row) for row in results]}
 
 
 @blp.route("/catalogs/list")
@@ -2957,57 +3007,33 @@ class ObjectsListResource(MethodView):
 
     def _get_objects(self, args):
         """Helper method to get objects based on filters, sorting, and paging"""
-        # Base query
-        query = """
-            SELECT object_id, name, ra, decl, descr, comment, type, epoch, const,
-                   magn, x, y, altname, distance, catalog
-            FROM objects
-        """
-
-        count_query = "SELECT COUNT(*) FROM objects"
-
-        # Build where clause and parameters
-        where_clauses = []
-        params = []
-
-        # Apply filters
-        if args.get('catalog'):
-            where_clauses.append("catalog ILIKE %s")
-            params.append(args['catalog'])
-
-        if args.get('constellation'):
-            where_clauses.append("const ILIKE %s")
-            params.append(args['constellation'])
-
-        if args.get('name'):
-            where_clauses.append("name ILIKE %s")
-            params.append(f"%{args['name']}%")
-
-        # Add where clauses to queries
-        if where_clauses:
-            where_str = " WHERE " + " AND ".join(where_clauses)
-            query += where_str
-            count_query += where_str
-
-        # Add sorting
-        sort_field = args.get('sort_by', 'name')
-        sort_order = args.get('sort_order', 'asc').upper()
-        query += f" ORDER BY {sort_field} {sort_order}"
-
-        # Add pagination
         page = args.get('page', 1)
         per_page = args.get('per_page', 100)
         offset = (page - 1) * per_page
-        query += f" LIMIT {per_page} OFFSET {offset}"
 
-        # Execute queries
         cnx = db.connect()
-
-        # Get total count
-        total_count = db.run_query(cnx, count_query, params)[0][0]
-
-        # Get paginated results
-        objects_list = db.run_query(cnx, query, params)
+        total_count = db.catalog_objects_count(
+            cnx,
+            catalog=args.get('catalog'),
+            constellation=args.get('constellation'),
+            name=args.get('name'),
+            ra_hours=args.get('ra'),
+            decl=args.get('decl'),
+            proximity=args.get('proximity', 1.0),
+        )
+        objects_list = db.catalog_objects_search(
+            cnx,
+            catalog=args.get('catalog'),
+            constellation=args.get('constellation'),
+            name=args.get('name'),
+            ra_hours=args.get('ra'),
+            decl=args.get('decl'),
+            proximity=args.get('proximity', 1.0),
+            sort_by=args.get('sort_by', 'name'),
+            sort_order=args.get('sort_order', 'asc'),
+            limit=per_page,
+            offset=offset,
+        )
         cnx.close()
 
         logger.info(
@@ -3015,37 +3041,14 @@ class ObjectsListResource(MethodView):
             len(objects_list), page, total_count
         )
 
-        # Format objects
-        formatted_objects = []
-        for obj in objects_list:
-            obj_dict = {
-                'object_id': obj[0],
-                'name': obj[1],
-                'ra': obj[2],
-                'decl': obj[3],
-                'descr': obj[4],
-                'comment': obj[5],
-                'type': obj[6],
-                'epoch': obj[7],
-                'const': obj[8],
-                'magn': obj[9],
-                'x': obj[10],
-                'y': obj[11],
-                'altname': obj[12],
-                'distance': obj[13],
-                'catalog': obj[14]
-            }
-            formatted_objects.append(obj_dict)
-
-        # Calculate total pages
-        total_pages = (total_count + per_page - 1) // per_page
+        total_pages = (total_count + per_page - 1) // per_page if per_page else 0
 
         return {
-            "objects": formatted_objects,
+            "objects": [_object_row_to_dict(obj) for obj in objects_list],
             "total": total_count,
             "page": page,
             "per_page": per_page,
-            "pages": total_pages
+            "pages": total_pages,
         }
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::marshmallow.warnings.RemovedInMarshmallow4Warning

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ flask
 flask-cors
 flask-smorest
 flask-jwt-extended
+webargs>=8.7.1
 
 argon2-cffi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ tenacity==9.0.0
     # via plotly
 tzdata==2024.2
     # via pandas
-webargs==8.6.0
+webargs==8.7.1
     # via flask-smorest
 werkzeug==3.1.6
     # via

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""
+Pytest configuration shared by all tests.
+"""
+
+import warnings
+
+from marshmallow import warnings as marshmallow_warnings
+
+# Marshmallow 4 migration notices from dependencies and legacy field options.
+warnings.filterwarnings("ignore", category=marshmallow_warnings.RemovedInMarshmallow4Warning)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,19 +4,13 @@
 
 import unittest
 import os
-import warnings
 import json
 import time
 from datetime import datetime
 from flask_jwt_extended import create_access_token
 from tests.dbtest import use_repository
-from marshmallow import warnings as marshmallow_warnings
 from hevelius import db
-
-# Suppress the specific marshmallow warning
-warnings.filterwarnings("ignore", category=marshmallow_warnings.RemovedInMarshmallow4Warning)
-
-from heveliusbackend.app import app  # noqa: E402
+from heveliusbackend.app import app
 
 
 class TestTaskAdd(unittest.TestCase):

--- a/tests/test_api_catalogs.py
+++ b/tests/test_api_catalogs.py
@@ -129,11 +129,12 @@ class TestCatalogs(unittest.TestCase):
         data = json.loads(response.data)
         self.assertTrue(all(obj['catalog'] == 'ngc' for obj in data['objects']))
 
-        # Test filtering by name
-        response = self.app.get('/api/catalogs/list?name=7000', headers=self.headers)
+        # Test filtering by name (matches name or altname)
+        response = self.app.get('/api/catalogs/list?name=7000&catalog=ngc', headers=self.headers)
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
-        self.assertTrue(all('7000' in obj['name'].lower() for obj in data['objects']))
+        self.assertGreaterEqual(data['total'], 1)
+        self.assertIn('NGC7000', {obj['name'] for obj in data['objects']})
 
         os.environ.pop('HEVELIUS_DB_NAME')
 
@@ -264,8 +265,104 @@ class TestCatalogs(unittest.TestCase):
 
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    @use_repository
+    def test_catalogs_installed_list(self, config):
+        """Test installed catalogs list endpoint"""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect(config)
+        db.run_query(cnx, """
+            INSERT INTO catalogs (name, shortname, filename, descr, url, version)
+            VALUES
+            ('Test NGC', 'TNGC', 'ngc.dat', 'NGC', 'http://example.com/ngc', '1.0'),
+            ('Test Messier', 'TM', 'm.dat', 'M', 'http://example.com/m', '1.0')
+            RETURNING shortname""")
+        db.run_query(cnx, """
+            INSERT INTO objects (name, ra, decl, descr, type, catalog)
+            VALUES
+            ('TNGC7000', 20.99, 44.37, 'North America Nebula', 'EN', 'TNGC'),
+            ('TNGC7001', 21.00, 44.45, 'Spiral Galaxy', 'G', 'TNGC'),
+            ('TM31', 0.71, 41.27, 'Andromeda Galaxy', 'G', 'TM')
+            RETURNING object_id""")
+        tngc_count = db.run_query(cnx, "SELECT COUNT(*) FROM objects WHERE catalog = 'TNGC'")[0][0]
+        tm_count = db.run_query(cnx, "SELECT COUNT(*) FROM objects WHERE catalog = 'TM'")[0][0]
+        cnx.close()
+
+        response = self.app.get('/api/catalogs?sort=entries', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIn('catalogs', data)
+        by_short = {c['shortname']: c for c in data['catalogs'] if c['shortname'] in ('TNGC', 'TM')}
+        self.assertEqual(len(by_short), 2)
+        self.assertEqual(by_short['TNGC']['object_count'], tngc_count)
+        self.assertEqual(by_short['TM']['object_count'], tm_count)
+
+        response = self.app.get('/api/catalogs?sort=name', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        names = [c['name'].lower() for c in data['catalogs']]
+        self.assertEqual(names, sorted(names))
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_catalog_list_filter_by_coordinates(self, config):
+        """Test catalog list filtering by RA/decl proximity"""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect(config)
+        db.run_query(cnx, """
+            INSERT INTO catalogs (name, shortname, filename, descr, url, version)
+            VALUES ('Test Messier', 'TM', 'm.dat', 'M', 'http://example.com/m', '1.0')
+            RETURNING shortname""")
+        db.run_query(cnx, """
+            INSERT INTO objects (name, ra, decl, descr, type, catalog)
+            VALUES
+            ('TM31', 0.71, 41.27, 'Andromeda Galaxy', 'G', 'TM'),
+            ('TM8', 18.06, -24.38, 'Lagoon Nebula', 'EN', 'TM')
+            RETURNING object_id""")
+        cnx.close()
+
+        response = self.app.get(
+            '/api/catalogs/list?ra=0.71&decl=41.27&proximity=2.0',
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        names = {obj['name'] for obj in data['objects']}
+        self.assertIn('TM31', names)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_catalog_list_name_matches_altname(self, config):
+        """Test that name filter matches altname as well as name"""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect(config)
+        db.run_query(cnx, """
+            INSERT INTO catalogs (name, shortname, filename, descr, url, version)
+            VALUES ('Test NGC', 'TNGC', 'ngc.dat', 'NGC', 'http://example.com/ngc', '1.0')
+            RETURNING shortname""")
+        db.run_query(cnx, """
+            INSERT INTO objects (name, ra, decl, descr, type, catalog, altname)
+            VALUES ('TNGC7000', 20.99, 44.37, 'North America Nebula', 'EN', 'TNGC', '7000')
+            RETURNING object_id""")
+        cnx.close()
+
+        response = self.app.get('/api/catalogs/list?name=7000', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertGreaterEqual(data['total'], 1)
+        self.assertIn('TNGC7000', {obj['name'] for obj in data['objects']})
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
     def test_unauthorized_access(self):
         """Test unauthorized access to endpoints"""
+        response = self.app.get('/api/catalogs')
+        self.assertEqual(response.status_code, 401)
+
         # Test search endpoint without token
         response = self.app.get('/api/catalogs/search?query=ngc7')
         self.assertEqual(response.status_code, 401)
@@ -293,6 +390,10 @@ class TestCatalogs(unittest.TestCase):
 
         # Test invalid per_page value
         response = self.app.get('/api/catalogs/list?per_page=0', headers=self.headers)
+        self.assertEqual(response.status_code, 422)
+
+        # ra without decl
+        response = self.app.get('/api/catalogs/list?ra=1.0', headers=self.headers)
         self.assertEqual(response.status_code, 422)
 
         os.environ.pop('HEVELIUS_DB_NAME')

--- a/tests/test_cmd_catalogs.py
+++ b/tests/test_cmd_catalogs.py
@@ -158,11 +158,29 @@ class TestCmdCatalogs(unittest.TestCase):
             sort="name",
             sort_order="asc",
             limit=None,
+            radius=None,
         )
         with patch("sys.stdout", new_callable=io.StringIO) as out:
             rc = find_catalog_objects(args)
         self.assertEqual(rc, 0)
         self.assertIn("TM31", out.getvalue())
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_fetch_catalog_objects_radius(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        cnx = db.connect(config)
+        _seed_catalogs(cnx)
+        cnx.close()
+
+        near_m31 = fetch_catalog_objects(ra_hours=0.71, decl=41.27, proximity=1.0)
+        near_m8 = fetch_catalog_objects(ra_hours=18.06, decl=-24.38, proximity=1.0)
+        m31_names = {o["name"] for o in near_m31}
+        m8_names = {o["name"] for o in near_m8}
+        self.assertIn("TM31", m31_names)
+        self.assertIn("TM8", m8_names)
+        self.assertNotIn("TM8", m31_names)
+
         os.environ.pop("HEVELIUS_DB_NAME")
 
     def test_find_catalog_objects_ra_dec_validation(self):
@@ -175,10 +193,27 @@ class TestCmdCatalogs(unittest.TestCase):
             sort="name",
             sort_order="asc",
             limit=None,
+            radius=None,
         )
         with patch("sys.stderr", new_callable=io.StringIO):
             with self.assertRaises(SystemExit):
                 find_catalog_objects(args)
+
+    def test_find_catalog_objects_radius_requires_coords(self):
+        args = Namespace(
+            name=None,
+            catalog=None,
+            const=None,
+            ra=None,
+            dec=None,
+            sort="name",
+            sort_order="asc",
+            limit=None,
+            radius=2.0,
+        )
+        with patch("sys.stderr", new_callable=io.StringIO):
+            rc = find_catalog_objects(args)
+        self.assertEqual(rc, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_cmd_catalogs.py
+++ b/tests/test_cmd_catalogs.py
@@ -1,6 +1,5 @@
 import io
 import os
-import sys
 import unittest
 from argparse import Namespace
 from unittest.mock import patch

--- a/tests/test_cmd_catalogs.py
+++ b/tests/test_cmd_catalogs.py
@@ -1,0 +1,186 @@
+import io
+import os
+import sys
+import unittest
+from argparse import Namespace
+from unittest.mock import patch
+
+from tests.dbtest import use_repository
+from hevelius import db
+from hevelius.cmd_catalogs import (
+    fetch_catalog_objects,
+    fetch_installed_catalogs,
+    find_catalog_objects,
+    list_catalogs,
+    render_catalogs_text,
+    render_objects_text,
+)
+
+
+def _seed_catalogs(cnx):
+    db.run_query(
+        cnx,
+        """
+        INSERT INTO catalogs (name, shortname, filename, descr, url, version)
+        VALUES
+        ('Test New General Catalogue', 'TNGC', 'ngc.dat', 'NGC', 'http://example.com/ngc', '1.0'),
+        ('Test Messier Catalogue', 'TM', 'm.dat', 'Messier', 'http://example.com/m', '1.0')
+        """,
+    )
+    db.run_query(
+        cnx,
+        """
+        INSERT INTO objects (name, ra, decl, descr, type, catalog, const, magn, altname)
+        VALUES
+        ('TNGC7000', 20.99, 44.37, 'North America Nebula', 'EN', 'TNGC', 'Cyg', 4.0, '7000'),
+        ('TNGC7001', 21.00, 44.45, 'Spiral Galaxy', 'G', 'TNGC', 'Cyg', 13.0, NULL),
+        ('TM31', 0.71, 41.27, 'Andromeda Galaxy', 'G', 'TM', 'And', 3.4, NULL),
+        ('TM8', 18.06, -24.38, 'Lagoon Nebula', 'EN', 'TM', 'Sgr', 6.0, NULL)
+        """,
+    )
+
+
+class TestCmdCatalogs(unittest.TestCase):
+    @use_repository
+    def test_fetch_installed_catalogs_sort_entries(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        cnx = db.connect(config)
+        _seed_catalogs(cnx)
+        cnx.close()
+
+        catalogs = fetch_installed_catalogs(sort_by="entries")
+        test_catalogs = [c for c in catalogs if c["shortname"] in ("TNGC", "TM")]
+        self.assertEqual(len(test_catalogs), 2)
+        self.assertTrue(all(c["object_count"] == 2 for c in test_catalogs))
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_fetch_installed_catalogs_sort_name(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        cnx = db.connect(config)
+        _seed_catalogs(cnx)
+        cnx.close()
+
+        catalogs = fetch_installed_catalogs(sort_by="name", sort_order="asc")
+        names = [c["name"].lower() for c in catalogs]
+        self.assertEqual(names, sorted(names))
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_fetch_catalog_objects_filters(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        cnx = db.connect(config)
+        _seed_catalogs(cnx)
+        cnx.close()
+
+        by_catalog = fetch_catalog_objects(catalog="TNGC")
+        self.assertEqual(len(by_catalog), 2)
+        self.assertTrue(all(o["catalog"] == "TNGC" for o in by_catalog))
+
+        by_name = fetch_catalog_objects(name="7000")
+        self.assertGreaterEqual(len(by_name), 1)
+        self.assertIn("TNGC7000", {o["name"] for o in by_name})
+
+        by_const = fetch_catalog_objects(constellation="Sgr")
+        self.assertEqual(len(by_const), 1)
+        self.assertEqual(by_const[0]["name"], "TM8")
+
+        limited = fetch_catalog_objects(sort_by="name", limit=2)
+        self.assertEqual(len(limited), 2)
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_fetch_catalog_objects_coords(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        cnx = db.connect(config)
+        _seed_catalogs(cnx)
+        cnx.close()
+
+        # TM31 is near RA 0h 43m, Dec +41°
+        nearby = fetch_catalog_objects(ra_hours=0.71, decl=41.27, proximity=2.0)
+        names = {o["name"] for o in nearby}
+        self.assertIn("TM31", names)
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    def test_render_catalogs_text_empty(self):
+        self.assertEqual(render_catalogs_text([]), "No catalogs found.")
+
+    def test_render_objects_text(self):
+        text = render_objects_text([
+            {
+                "object_id": 1,
+                "name": "M31",
+                "ra": 0.71,
+                "decl": 41.27,
+                "descr": "Andromeda",
+                "comment": None,
+                "type": "G",
+                "epoch": None,
+                "const": "And",
+                "magn": 3.4,
+                "x": None,
+                "y": None,
+                "altname": None,
+                "distance": None,
+                "catalog": "M",
+            }
+        ])
+        self.assertIn("M31", text)
+        self.assertIn("Andromeda", text)
+
+    @use_repository
+    def test_list_catalogs_cli(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        cnx = db.connect(config)
+        _seed_catalogs(cnx)
+        cnx.close()
+
+        args = Namespace(sort="entries")
+        with patch("sys.stdout", new_callable=io.StringIO) as out:
+            rc = list_catalogs(args)
+        self.assertEqual(rc, 0)
+        self.assertIn("TNGC", out.getvalue())
+        self.assertIn("Objects", out.getvalue())
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    @use_repository
+    def test_find_catalog_objects_cli(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        cnx = db.connect(config)
+        _seed_catalogs(cnx)
+        cnx.close()
+
+        args = Namespace(
+            name="TM31",
+            catalog=None,
+            const=None,
+            ra=None,
+            dec=None,
+            sort="name",
+            sort_order="asc",
+            limit=None,
+        )
+        with patch("sys.stdout", new_callable=io.StringIO) as out:
+            rc = find_catalog_objects(args)
+        self.assertEqual(rc, 0)
+        self.assertIn("TM31", out.getvalue())
+        os.environ.pop("HEVELIUS_DB_NAME")
+
+    def test_find_catalog_objects_ra_dec_validation(self):
+        args = Namespace(
+            name=None,
+            catalog=None,
+            const=None,
+            ra="12 00 00",
+            dec=None,
+            sort="name",
+            sort_order="asc",
+            limit=None,
+        )
+        with patch("sys.stderr", new_callable=io.StringIO):
+            with self.assertRaises(SystemExit):
+                find_catalog_objects(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -65,6 +65,7 @@ class TestOpenAPISpec(unittest.TestCase):
             "/api/projects/{project_id}/tasks/{task_id}",
             "/api/projects/{project_id}/subframes",
             "/api/projects/{project_id}/subframes/{subframe_id}",
+            "/api/catalogs",
             "/api/catalogs/search",
             "/api/catalogs/list",
         }


### PR DESCRIPTION
It implements the following:

- CLI: `hevelius catalogs` lists installed catalogs with object counts (`--sort entries|name`).
- CLI: `hevelius catalog` searches catalog objects by name, catalog, constellation,
  and optional coordinates (`--ra`/`--dec`, `--sort`, `--limit`).
