### PR TITLE
Add camera rotation and optical parameters to projects (schema v23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project versioning adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (unreleased)
+- DB: schema bumped to 22: asteroids data now available.
+- DB: schema bumped to 23: camera rotation, camera details in the projects.
+- API: The telescopes now have a default camera rotation. The projects now have camera rotation.
+  If not specified, the default from the telescope is copied.
+- CLI: It's possible to specify default rotation for a telescope, and an image rotation for
+  a project.
+
 ## 0.5.1 (2026-05-26)
 
 - CLI: `hevelius catalogs` lists installed catalogs with object counts (`--sort entries|name`).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -610,6 +610,29 @@ components:
           description: >
             Nominal camera position angle in degrees (0–360, East of North, same convention
             as the FITS PA keyword). null means not set. 0.0 means North up, no rotation.
+        focal:
+          type: number
+          format: float
+          nullable: true
+          description: Focal length (mm) at the time the project was created; copied from the telescope's focal length.
+        resx:
+          type: integer
+          nullable: true
+          description: Sensor width in pixels; copied from the telescope's attached sensor at project creation.
+        resy:
+          type: integer
+          nullable: true
+          description: Sensor height in pixels; copied from the telescope's attached sensor at project creation.
+        pixel_x:
+          type: number
+          format: float
+          nullable: true
+          description: Pixel pitch in X axis (µm); copied from the telescope's attached sensor at project creation.
+        pixel_y:
+          type: number
+          format: float
+          nullable: true
+          description: Pixel pitch in Y axis (µm); copied from the telescope's attached sensor at project creation.
         subframes:
           type: array
           items:
@@ -666,6 +689,31 @@ components:
           description: >
             Nominal camera position angle in degrees (0–360, East of North).
             Omit or send null to leave unset.
+        focal:
+          type: number
+          format: float
+          nullable: true
+          description: >
+            Focal length (mm). Auto-populated from the telescope's focal when omitted.
+            Supply explicitly to override (e.g. with a focal reducer).
+        resx:
+          type: integer
+          nullable: true
+          description: Sensor width (pixels). Auto-populated from the telescope's sensor when omitted.
+        resy:
+          type: integer
+          nullable: true
+          description: Sensor height (pixels). Auto-populated from the telescope's sensor when omitted.
+        pixel_x:
+          type: number
+          format: float
+          nullable: true
+          description: Pixel pitch X (µm). Auto-populated from the telescope's sensor when omitted.
+        pixel_y:
+          type: number
+          format: float
+          nullable: true
+          description: Pixel pitch Y (µm). Auto-populated from the telescope's sensor when omitted.
     ProjectUpdate:
       type: object
       properties:
@@ -706,6 +754,29 @@ components:
           description: >
             Nominal camera position angle in degrees (0–360, East of North).
             Send null to clear the value.
+        focal:
+          type: number
+          format: float
+          nullable: true
+          description: Focal length (mm). Send null to clear.
+        resx:
+          type: integer
+          nullable: true
+          description: Sensor width (pixels). Send null to clear.
+        resy:
+          type: integer
+          nullable: true
+          description: Sensor height (pixels). Send null to clear.
+        pixel_x:
+          type: number
+          format: float
+          nullable: true
+          description: Pixel pitch X (µm). Send null to clear.
+        pixel_y:
+          type: number
+          format: float
+          nullable: true
+          description: Pixel pitch Y (µm). Send null to clear.
     ProjectsList:
       type: object
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -688,7 +688,8 @@ components:
           nullable: true
           description: >
             Nominal camera position angle in degrees (0–360, East of North).
-            Omit or send null to leave unset.
+            Auto-populated from the telescope's default_rotation when omitted, if set
+            there; otherwise left unset. Supply explicitly to override.
         focal:
           type: number
           format: float
@@ -861,6 +862,14 @@ components:
         active:
           type: boolean
           description: Whether the telescope is active
+        default_rotation:
+          type: number
+          format: float
+          nullable: true
+          description: >
+            Default camera position angle in degrees (0–360, East of North) applied to
+            new projects created on this telescope when their rotation is not specified.
+            null means no default is set.
     TelescopesList:
       type: object
       properties:
@@ -908,6 +917,13 @@ components:
         active:
           type: boolean
           default: true
+        default_rotation:
+          type: number
+          format: float
+          nullable: true
+          description: >
+            Default camera position angle in degrees (0–360, East of North) applied to
+            new projects created on this telescope when their rotation is not specified.
     ScopeUpdate:
       type: object
       properties:
@@ -943,6 +959,13 @@ components:
           description: Camera/sensor ID; use 0 to remove sensor
         active:
           type: boolean
+        default_rotation:
+          type: number
+          format: float
+          nullable: true
+          description: >
+            Default camera position angle in degrees (0–360, East of North) for new
+            projects on this telescope. Send null to clear.
     ScopeResponse:
       type: object
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -603,6 +603,13 @@ components:
           type: string
           nullable: true
           description: Space-separated URLs of published media (social posts, galleries, etc.)
+        rotation:
+          type: number
+          format: float
+          nullable: true
+          description: >
+            Nominal camera position angle in degrees (0–360, East of North, same convention
+            as the FITS PA keyword). null means not set. 0.0 means North up, no rotation.
         subframes:
           type: array
           items:
@@ -652,6 +659,13 @@ components:
           type: string
           nullable: true
           description: Space-separated publication URLs
+        rotation:
+          type: number
+          format: float
+          nullable: true
+          description: >
+            Nominal camera position angle in degrees (0–360, East of North).
+            Omit or send null to leave unset.
     ProjectUpdate:
       type: object
       properties:
@@ -685,6 +699,13 @@ components:
           type: string
           nullable: true
           description: Space-separated publication URLs; send null or empty string to clear
+        rotation:
+          type: number
+          format: float
+          nullable: true
+          description: >
+            Nominal camera position angle in degrees (0–360, East of North).
+            Send null to clear the value.
     ProjectsList:
       type: object
       properties:

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -229,6 +229,8 @@ def run():
     project_add.add_argument('--ra', type=float, default=None, help="RA in hours (omit to resolve from catalog by name)")
     project_add.add_argument('--dec', type=float, default=None, help="Declination in degrees (omit to resolve from catalog by name)")
     project_add.add_argument('--description', default='', help="Project description")
+    project_add.add_argument('--rotation', type=float, default=None,
+                              help="Camera position angle in degrees, East of North (defaults to the telescope's default_rotation if omitted)")
     project_add.add_argument('--active', action='store_true', default=True, help="Project is active (default)")
     project_add.add_argument('--inactive', action='store_true', help="Create project as inactive")
     project_edit = project_sub.add_parser('edit', help="Edit an existing project")
@@ -238,6 +240,7 @@ def run():
     project_edit.add_argument('--description', default=None, help="Project description")
     project_edit.add_argument('--ra', type=float, default=None, help="RA in hours")
     project_edit.add_argument('--dec', type=float, default=None, help="Declination in degrees")
+    project_edit.add_argument('--rotation', type=float, default=None, help="Camera position angle in degrees, East of North")
     project_edit.add_argument('--active', action='store_true', help="Set project active")
     project_edit.add_argument('--inactive', action='store_true', help="Set project inactive")
     project_show = project_sub.add_parser('show', help="Show project details")
@@ -293,6 +296,8 @@ def run():
     t_add.add_argument('--lat', type=float, help="Latitude")
     t_add.add_argument('--alt', type=float, help="Altitude")
     t_add.add_argument('--sensor-id', type=int, default=None, help="Sensor ID (0 or omit = none)")
+    t_add.add_argument('--default-rotation', type=float, default=None,
+                        help="Default camera position angle in degrees, East of North; used for new projects on this telescope when their rotation is not specified")
     t_add.add_argument('--active', action='store_true', default=True, help="Telescope is active (default)")
     t_add.add_argument('--inactive', action='store_true', help="Create telescope as inactive")
     t_edit = telescope_sub.add_parser('edit', help="Edit an existing telescope")
@@ -307,6 +312,8 @@ def run():
     t_edit.add_argument('--lat', type=float, help="Latitude")
     t_edit.add_argument('--alt', type=float, help="Altitude")
     t_edit.add_argument('--sensor-id', type=int, default=None, help="Sensor ID (0 to remove)")
+    t_edit.add_argument('--default-rotation', type=float, default=None,
+                         help="Default camera position angle in degrees, East of North; used for new projects on this telescope when their rotation is not specified")
     t_edit.add_argument('--active', action='store_true', help="Set active")
     t_edit.add_argument('--inactive', action='store_true', help="Set inactive")
     t_show = telescope_sub.add_parser('show', help="Show telescope details (sensor + filters)")
@@ -467,7 +474,8 @@ def run():
                 description=getattr(args, 'description', '') or '',
                 ra=getattr(args, 'ra', None),
                 dec=getattr(args, 'dec', None),
-                active=active
+                active=active,
+                rotation=getattr(args, 'rotation', None)
             )
             if pid is None:
                 print("Failed to add project: name not in catalog (provide --ra and --dec) or invalid scope_id.", file=sys.stderr)
@@ -487,7 +495,8 @@ def run():
                 scope_id=getattr(args, 'scope_id', None),
                 ra=getattr(args, 'ra', None),
                 dec=getattr(args, 'dec', None),
-                active=active
+                active=active,
+                rotation=getattr(args, 'rotation', None)
             )
             return 0 if ok else 1
         if args.project_command == "delete":
@@ -582,7 +591,8 @@ def run():
                 lat=getattr(args, 'lat', None),
                 alt=getattr(args, 'alt', None),
                 sensor_id=getattr(args, 'sensor_id', None),
-                active=active
+                active=active,
+                default_rotation=getattr(args, 'default_rotation', None)
             ) is not None else 1
         if args.telescope_command == "edit":
             active = None
@@ -602,7 +612,8 @@ def run():
                 lat=getattr(args, 'lat', None),
                 alt=getattr(args, 'alt', None),
                 sensor_id=getattr(args, 'sensor_id', None),
-                active=active
+                active=active,
+                default_rotation=getattr(args, 'default_rotation', None)
             ) else 1
         if args.telescope_command == "show":
             return show_telescope(args.scope_id)

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -230,6 +230,11 @@ def run():
     project_add.add_argument('--dec', type=float, default=None, help="Declination in degrees (omit to resolve from catalog by name)")
     project_add.add_argument('--description', default='', help="Project description")
     project_add.add_argument('--rotation', type=float, default=None, help="Camera angle in degrees, East of North (defaults to telescope's default_rotation)")
+    project_add.add_argument('--focal', type=float, default=None, help="Focal length (mm); defaults from telescope")
+    project_add.add_argument('--resx', type=int, default=None, help="Sensor width (pixels); defaults from sensor")
+    project_add.add_argument('--resy', type=int, default=None, help="Sensor height (pixels); defaults from sensor")
+    project_add.add_argument('--pixel-x', type=float, default=None, help="Pixel pitch X (µm); defaults from sensor")
+    project_add.add_argument('--pixel-y', type=float, default=None, help="Pixel pitch Y (µm); defaults from sensor")
     project_add.add_argument('--active', action='store_true', default=True, help="Project is active (default)")
     project_add.add_argument('--inactive', action='store_true', help="Create project as inactive")
     project_edit = project_sub.add_parser('edit', help="Edit an existing project")
@@ -240,6 +245,12 @@ def run():
     project_edit.add_argument('--ra', type=float, default=None, help="RA in hours")
     project_edit.add_argument('--dec', type=float, default=None, help="Declination in degrees")
     project_edit.add_argument('--rotation', type=float, default=None, help="Camera position angle in degrees, East of North")
+    project_edit.add_argument('--clear-rotation', action='store_true', help="Clear rotation (set to null)")
+    project_edit.add_argument('--focal', type=float, default=None, help="Focal length (mm)")
+    project_edit.add_argument('--resx', type=int, default=None, help="Sensor width (pixels)")
+    project_edit.add_argument('--resy', type=int, default=None, help="Sensor height (pixels)")
+    project_edit.add_argument('--pixel-x', type=float, default=None, help="Pixel pitch X (µm)")
+    project_edit.add_argument('--pixel-y', type=float, default=None, help="Pixel pitch Y (µm)")
     project_edit.add_argument('--active', action='store_true', help="Set project active")
     project_edit.add_argument('--inactive', action='store_true', help="Set project inactive")
     project_show = project_sub.add_parser('show', help="Show project details")
@@ -311,6 +322,7 @@ def run():
     t_edit.add_argument('--alt', type=float, help="Altitude")
     t_edit.add_argument('--sensor-id', type=int, default=None, help="Sensor ID (0 to remove)")
     t_edit.add_argument('--default-rotation', type=float, default=None, help="Default rotation (deg, East of North) for new projects on this telescope")
+    t_edit.add_argument('--clear-default-rotation', action='store_true', help="Clear default_rotation (set to null)")
     t_edit.add_argument('--active', action='store_true', help="Set active")
     t_edit.add_argument('--inactive', action='store_true', help="Set inactive")
     t_show = telescope_sub.add_parser('show', help="Show telescope details (sensor + filters)")
@@ -472,7 +484,12 @@ def run():
                 ra=getattr(args, 'ra', None),
                 dec=getattr(args, 'dec', None),
                 active=active,
-                rotation=getattr(args, 'rotation', None)
+                rotation=getattr(args, 'rotation', None),
+                focal=getattr(args, 'focal', None),
+                resx=getattr(args, 'resx', None),
+                resy=getattr(args, 'resy', None),
+                pixel_x=getattr(args, 'pixel_x', None),
+                pixel_y=getattr(args, 'pixel_y', None)
             )
             if pid is None:
                 print("Failed to add project: name not in catalog (provide --ra and --dec) or invalid scope_id.", file=sys.stderr)
@@ -485,6 +502,9 @@ def run():
                 active = True
             if getattr(args, 'inactive', False):
                 active = False
+            if getattr(args, 'clear_rotation', False) and getattr(args, 'rotation', None) is not None:
+                print("Error: specify only one of --rotation or --clear-rotation.", file=sys.stderr)
+                return 1
             ok = edit_project(
                 args.project_id,
                 name=getattr(args, 'name', None),
@@ -493,7 +513,13 @@ def run():
                 ra=getattr(args, 'ra', None),
                 dec=getattr(args, 'dec', None),
                 active=active,
-                rotation=getattr(args, 'rotation', None)
+                rotation=getattr(args, 'rotation', None),
+                clear_rotation=getattr(args, 'clear_rotation', False),
+                focal=getattr(args, 'focal', None),
+                resx=getattr(args, 'resx', None),
+                resy=getattr(args, 'resy', None),
+                pixel_x=getattr(args, 'pixel_x', None),
+                pixel_y=getattr(args, 'pixel_y', None)
             )
             return 0 if ok else 1
         if args.project_command == "delete":
@@ -597,6 +623,11 @@ def run():
                 active = True
             if getattr(args, 'inactive', False):
                 active = False
+            if (getattr(args, 'clear_default_rotation', False)
+                    and getattr(args, 'default_rotation', None) is not None):
+                print("Error: specify only one of --default-rotation or --clear-default-rotation.",
+                      file=sys.stderr)
+                return 1
             return 0 if edit_telescope(
                 args.scope_id,
                 name=getattr(args, 'name', None),
@@ -610,7 +641,8 @@ def run():
                 alt=getattr(args, 'alt', None),
                 sensor_id=getattr(args, 'sensor_id', None),
                 active=active,
-                default_rotation=getattr(args, 'default_rotation', None)
+                default_rotation=getattr(args, 'default_rotation', None),
+                clear_default_rotation=getattr(args, 'clear_default_rotation', False)
             ) else 1
         if args.telescope_command == "show":
             return show_telescope(args.scope_id)

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -229,8 +229,7 @@ def run():
     project_add.add_argument('--ra', type=float, default=None, help="RA in hours (omit to resolve from catalog by name)")
     project_add.add_argument('--dec', type=float, default=None, help="Declination in degrees (omit to resolve from catalog by name)")
     project_add.add_argument('--description', default='', help="Project description")
-    project_add.add_argument('--rotation', type=float, default=None,
-                              help="Camera position angle in degrees, East of North (defaults to the telescope's default_rotation if omitted)")
+    project_add.add_argument('--rotation', type=float, default=None, help="Camera angle in degrees, East of North (defaults to telescope's default_rotation)")
     project_add.add_argument('--active', action='store_true', default=True, help="Project is active (default)")
     project_add.add_argument('--inactive', action='store_true', help="Create project as inactive")
     project_edit = project_sub.add_parser('edit', help="Edit an existing project")
@@ -296,8 +295,7 @@ def run():
     t_add.add_argument('--lat', type=float, help="Latitude")
     t_add.add_argument('--alt', type=float, help="Altitude")
     t_add.add_argument('--sensor-id', type=int, default=None, help="Sensor ID (0 or omit = none)")
-    t_add.add_argument('--default-rotation', type=float, default=None,
-                        help="Default camera position angle in degrees, East of North; used for new projects on this telescope when their rotation is not specified")
+    t_add.add_argument('--default-rotation', type=float, default=None, help="Default rotation (deg, East of North) for new projects on this telescope")
     t_add.add_argument('--active', action='store_true', default=True, help="Telescope is active (default)")
     t_add.add_argument('--inactive', action='store_true', help="Create telescope as inactive")
     t_edit = telescope_sub.add_parser('edit', help="Edit an existing telescope")
@@ -312,8 +310,7 @@ def run():
     t_edit.add_argument('--lat', type=float, help="Latitude")
     t_edit.add_argument('--alt', type=float, help="Altitude")
     t_edit.add_argument('--sensor-id', type=int, default=None, help="Sensor ID (0 to remove)")
-    t_edit.add_argument('--default-rotation', type=float, default=None,
-                         help="Default camera position angle in degrees, East of North; used for new projects on this telescope when their rotation is not specified")
+    t_edit.add_argument('--default-rotation', type=float, default=None, help="Default rotation (deg, East of North) for new projects on this telescope")
     t_edit.add_argument('--active', action='store_true', help="Set active")
     t_edit.add_argument('--inactive', action='store_true', help="Set inactive")
     t_show = telescope_sub.add_parser('show', help="Show telescope details (sensor + filters)")

--- a/db/23-project-rotation.psql
+++ b/db/23-project-rotation.psql
@@ -24,7 +24,9 @@ ALTER TABLE projects ADD COLUMN pixel_y FLOAT DEFAULT NULL;
 
 ALTER TABLE telescopes ADD COLUMN default_rotation FLOAT DEFAULT NULL;
 
--- Back-fill existing projects from their telescope's attached sensor.
+-- Back-fill existing projects from their telescope (focal) and attached sensor
+-- (res/pixel). LEFT JOIN so focal is copied even when the telescope has no sensor;
+-- sensor columns stay NULL in that case.
 UPDATE projects p
 SET
     focal   = t.focal,
@@ -34,7 +36,6 @@ SET
     pixel_y = s.pixel_y
 FROM telescopes t
 LEFT JOIN sensors s ON s.sensor_id = t.sensor_id
-WHERE t.scope_id = p.scope_id
-  AND t.sensor_id IS NOT NULL;
+WHERE t.scope_id = p.scope_id;
 
 UPDATE schema_version SET version = 23;

--- a/db/23-project-rotation.psql
+++ b/db/23-project-rotation.psql
@@ -1,8 +1,32 @@
--- Schema version 23: add camera rotation to projects
+-- Schema version 23: add camera rotation and optical params to projects
 --
--- rotation stores the nominal camera position angle in degrees (0–360, East of North).
--- NULL means "not set / unknown"; 0.0 is a valid value (North up).
+-- rotation: nominal camera position angle in degrees (0–360, East of North).
+--   NULL means "not set / unknown"; 0.0 is a valid value (North up).
+--
+-- focal, resx, resy, pixel_x, pixel_y: optical parameters copied from the
+--   telescope's sensor at project creation time.  Stored on the project so
+--   the FOV is stable even if the equipment is later changed, and so that
+--   the frontend needs no separate scopes API call to render the sky view.
+--   All are nullable (sensor may be absent at creation time).
 --
 ALTER TABLE projects ADD COLUMN rotation FLOAT DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN focal FLOAT DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN resx INTEGER DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN resy INTEGER DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN pixel_x FLOAT DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN pixel_y FLOAT DEFAULT NULL;
+
+-- Back-fill existing projects from their telescope's attached sensor.
+UPDATE projects p
+SET
+    focal   = t.focal,
+    resx    = s.resx,
+    resy    = s.resy,
+    pixel_x = s.pixel_x,
+    pixel_y = s.pixel_y
+FROM telescopes t
+LEFT JOIN sensors s ON s.sensor_id = t.sensor_id
+WHERE t.scope_id = p.scope_id
+  AND t.sensor_id IS NOT NULL;
 
 UPDATE schema_version SET version = 23;

--- a/db/23-project-rotation.psql
+++ b/db/23-project-rotation.psql
@@ -1,0 +1,8 @@
+-- Schema version 23: add camera rotation to projects
+--
+-- rotation stores the nominal camera position angle in degrees (0–360, East of North).
+-- NULL means "not set / unknown"; 0.0 is a valid value (North up).
+--
+ALTER TABLE projects ADD COLUMN rotation FLOAT DEFAULT NULL;
+
+UPDATE schema_version SET version = 23;

--- a/db/23-project-rotation.psql
+++ b/db/23-project-rotation.psql
@@ -9,12 +9,20 @@
 --   the frontend needs no separate scopes API call to render the sky view.
 --   All are nullable (sensor may be absent at creation time).
 --
+-- telescopes.default_rotation: optional per-telescope default for the
+--   project's rotation field above. When a new project is created without
+--   an explicit rotation, it is copied from the telescope's default_rotation
+--   (if set); otherwise the project's rotation stays NULL. Nullable; 0.0 is
+--   a valid value (North up).
+--
 ALTER TABLE projects ADD COLUMN rotation FLOAT DEFAULT NULL;
 ALTER TABLE projects ADD COLUMN focal FLOAT DEFAULT NULL;
 ALTER TABLE projects ADD COLUMN resx INTEGER DEFAULT NULL;
 ALTER TABLE projects ADD COLUMN resy INTEGER DEFAULT NULL;
 ALTER TABLE projects ADD COLUMN pixel_x FLOAT DEFAULT NULL;
 ALTER TABLE projects ADD COLUMN pixel_y FLOAT DEFAULT NULL;
+
+ALTER TABLE telescopes ADD COLUMN default_rotation FLOAT DEFAULT NULL;
 
 -- Back-fill existing projects from their telescope's attached sensor.
 UPDATE projects p

--- a/doc/db.md
+++ b/doc/db.md
@@ -20,6 +20,15 @@ python bin/hevelius migrate
 
 he_solved_ra - Right Ascension, from the plate solving, in degrees (0-359)
 
+### Schema version 23 (project rotation, optical params, telescope default rotation)
+
+- **projects** – Added **rotation** (float, degrees East of North, nullable; user-supplied or defaulted
+  from the telescope, see below) and **focal**, **resx**, **resy**, **pixel_x**, **pixel_y** (optical
+  parameters, copied from the telescope's attached sensor at creation time, all nullable).
+- **telescopes** – Added **default_rotation** (float, degrees East of North, nullable). When a new
+  project is created on a telescope without an explicit `rotation`, it is copied from the telescope's
+  `default_rotation` (if set); otherwise the project's `rotation` stays NULL.
+
 ### Schema version 18 (users cleanup, audit, password reset)
 
 - **users** – **ftp_login** and **ftp_pass** removed. Non-empty **login** values are unique (partial unique index where `login IS NOT NULL`). Empty-string logins are normalized to NULL before the constraint is applied.

--- a/doc/db.md
+++ b/doc/db.md
@@ -29,6 +29,11 @@ he_solved_ra - Right Ascension, from the plate solving, in degrees (0-359)
   project is created on a telescope without an explicit `rotation`, it is copied from the telescope's
   `default_rotation` (if set); otherwise the project's `rotation` stays NULL.
 
+### Schema version 22 (asteroids)
+
+- **asteroids** – MPC orbital elements for visibility planning (`designation`, epoch, Keplerian
+  elements, absolute magnitude / slope). Used by asteroid night-visibility queries.
+
 ### Schema version 18 (users cleanup, audit, password reset)
 
 - **users** – **ftp_login** and **ftp_pass** removed. Non-empty **login** values are unique (partial unique index where `login IS NOT NULL`). Empty-string logins are normalized to NULL before the constraint is applied.

--- a/doc/sky-visualisation-plan.md
+++ b/doc/sky-visualisation-plan.md
@@ -19,7 +19,7 @@ Tasks are explicitly **out of scope** — the visualisation is based solely on t
 
 | Column | Type | Source | Notes |
 |--------|------|--------|-------|
-| `rotation` | `FLOAT` | user input | degrees East of North; NULL = not set |
+| `rotation` | `FLOAT` | user input, or `telescopes.default_rotation` | degrees East of North; NULL = not set |
 | `focal` | `FLOAT` | `telescopes.focal` | focal length (mm) |
 | `resx` | `INTEGER` | `sensors.resx` | sensor width (pixels) |
 | `resy` | `INTEGER` | `sensors.resy` | sensor height (pixels) |
@@ -27,6 +27,17 @@ Tasks are explicitly **out of scope** — the visualisation is based solely on t
 | `pixel_y` | `FLOAT` | `sensors.pixel_y` | pixel pitch Y (µm) |
 
 At project creation time the backend looks up the telescope's attached sensor and copies these values as defaults. They can be overridden via the edit endpoint (e.g. to model a different binning or a reducer/extender). For existing rows the migration fills them in via a `JOIN`.
+
+### New column on `telescopes`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `default_rotation` | `FLOAT` | Optional. Degrees East of North; NULL = no default. |
+
+When a project is created without an explicit `rotation`, the backend copies the telescope's
+`default_rotation` (if set); an explicit `rotation` in the request always wins. This lets a fixed
+imaging rig (camera bolted to the telescope at a known position angle) avoid having to repeat the
+same rotation value on every new project.
 
 ### FOV calculation (frontend or backend helper)
 
@@ -40,8 +51,9 @@ Because `focal`, `resx`, `resy`, `pixel_x`, `pixel_y` are now part of the projec
 ### API changes
 
 - `GET /api/projects` and `GET /api/projects/{id}` — response includes the five new fields
-- `POST /api/projects` — new optional fields `focal`, `resx`, `resy`, `pixel_x`, `pixel_y`; auto-populated from scope's sensor when omitted
+- `POST /api/projects` — new optional fields `focal`, `resx`, `resy`, `pixel_x`, `pixel_y`; auto-populated from scope's sensor when omitted. `rotation` auto-populated from the scope's `default_rotation` when omitted.
 - `PATCH /api/projects/{id}` — new optional fields, allowing override after creation
+- `GET /api/scopes`, `GET/POST /api/scopes/{id}`, `PATCH /api/scopes/{id}` — telescope responses/bodies include `default_rotation`
 
 ---
 
@@ -204,5 +216,6 @@ Pass the result to `A.polygon(corners)` in the Aladin overlay.
 
 - `rotation` convention: **degrees East of North**, 0–360 (same as FITS `PA` keyword and PixInsight plate-solve output). Values outside 0–360 are accepted by the DB and should be normalised modulo 360 on display.
 - The `rotation` field defaults to `NULL` in the DB, not `0`. The frontend should display a small indicator when it is null so users know it hasn't been configured rather than assuming North-up is correct.
+- A project's `rotation` is only auto-populated from the telescope's `default_rotation` at *creation* time (like the optical params). Changing a telescope's `default_rotation` later does not retroactively update existing projects.
 - Aladin Lite v3 is ESM-only; use a dynamic `import()` in the Angular component `ngAfterViewInit` to avoid SSR issues.
 - Optical params on `projects` are denormalised by design: they represent the imaging setup *as planned for this project*, which may differ from the telescope's current sensor (e.g. if the sensor is later swapped, or the user applies binning).

--- a/doc/sky-visualisation-plan.md
+++ b/doc/sky-visualisation-plan.md
@@ -1,0 +1,150 @@
+# Sky Visualisation — Implementation Plan
+
+## Overview
+
+Add a sky visualisation to the project detail page showing the telescope's camera field-of-view (FOV) frame overlaid on a real sky background, centred on the project's RA/Dec target. The camera rotation angle is the only piece of data that had to be added to the backend (this PR, schema v23); everything else (FOV size, pixel scale) can be derived from existing telescope and sensor data.
+
+## Scope
+
+- **Backend** (this PR): add `rotation` field to `projects` — ✅ done
+- **Frontend** (hevelius-web, follow-up): new Angular component + service
+
+Tasks are explicitly **out of scope** — the visualisation is based solely on the project's nominal pointing and the telescope/sensor geometry.
+
+---
+
+## Data available (no further backend changes needed)
+
+| Source | Fields used |
+|--------|-------------|
+| `Project` | `ra`, `decl`, `rotation`, `scope_id` |
+| `GET /api/scopes/{scope_id}` | `focal` (focal length, mm) |
+| Scope → sensor | `resx`, `resy` (pixels), `pixel_x`, `pixel_y` (micron/pixel) |
+
+### FOV calculation
+
+```
+FOV_width_deg  = 2 × arctan( (resx × pixel_x / 1000) / (2 × focal) ) × (180/π)
+FOV_height_deg = 2 × arctan( (resy × pixel_y / 1000) / (2 × focal) ) × (180/π)
+```
+
+All values already present in the existing API. No new backend endpoint needed.
+
+---
+
+## Frontend plan (hevelius-web)
+
+### 1. Sky rendering library
+
+Use **[Aladin Lite v3](https://aladin.cds.unistra.fr/ADE/aladinLiteV3.gml)** — the standard for web-based interactive sky charts. It provides:
+- DSS / PanSTARRS / 2MASS background sky imagery
+- Overlay API for drawing custom shapes (rectangles, polygons)
+- Native zoom and pan
+- Install: `npm install aladin-lite` (or load from CDN)
+
+### 2. New files
+
+| File | Description |
+|------|-------------|
+| `src/app/components/sky-view/sky-view.component.ts` | Main visualisation component |
+| `src/app/components/sky-view/sky-view.component.html` | Template (single `<div>` host for Aladin) |
+| `src/app/components/sky-view/sky-view.component.scss` | Styles |
+| `src/app/services/footprints.service.ts` | Data-fetching service (scope + sensor) |
+| `src/app/models/project.ts` | Add `rotation?: number \| null` field |
+
+### 3. `SkyViewComponent` — inputs
+
+```typescript
+@Input() ra: number;           // degrees
+@Input() dec: number;          // degrees
+@Input() fovWidthDeg: number;  // computed from sensor + focal
+@Input() fovHeightDeg: number; // computed from sensor + focal
+@Input() rotation: number;     // degrees East of North; 0 if null
+@Input() fovMultiplier = 3;    // how many FOVs wide to show around the target
+```
+
+Behaviour:
+- Initialises Aladin Lite centred on `ra`/`dec`
+- Draws the nominal planned frame as a **dashed rectangle** (colour: white) rotated by `rotation`
+- Shows a crosshair at the exact target centre
+- Zoom level set so the frame fits comfortably (~ `fovMultiplier × max(fovWidth, fovHeight)`)
+
+### 4. Integration into `ProjectDetailComponent`
+
+Add a "Sky view" card below the project metadata panel. The card:
+1. Calls `GET /api/scopes/{scope_id}` (already used elsewhere — reuse `ScopesService`)
+2. Computes FOV from sensor data
+3. Passes results into `<app-sky-view>`
+4. Shows a spinner while loading; shows a "No telescope/sensor data" notice if the scope has no sensor
+
+```html
+<!-- in project-detail.component.html -->
+<mat-card *ngIf="project">
+  <mat-card-header><mat-card-title>Sky view</mat-card-title></mat-card-header>
+  <mat-card-content>
+    <app-sky-view
+      [ra]="project.ra"
+      [dec]="project.decl"
+      [fovWidthDeg]="fovWidth"
+      [fovHeightDeg]="fovHeight"
+      [rotation]="project.rotation ?? 0">
+    </app-sky-view>
+  </mat-card-content>
+</mat-card>
+```
+
+### 5. Project model update
+
+```typescript
+// src/app/models/project.ts  (add to existing interface)
+rotation?: number | null;
+```
+
+### 6. UX details
+
+- Default height of the sky view card: `400px` (CSS fixed, or configurable via input)
+- Background survey: default to `P/DSS2/color`; add a small dropdown to switch (2MASS, PanSTARRS, etc.)
+- If `rotation` is `null`, treat as `0` (North up) and show a small "(rotation not set)" badge
+- The frame rectangle is drawn using Aladin's `A.graphicOverlay()` with a rotated polygon computed from the four corners in WCS space
+
+### 7. Corner coordinate calculation
+
+To draw the rotated rectangle, compute the four corners from the centre:
+
+```typescript
+function fovCorners(ra: number, dec: number,
+                    wDeg: number, hDeg: number,
+                    rotDeg: number): [number, number][] {
+  const rotRad = rotDeg * Math.PI / 180;
+  const hw = wDeg / 2, hh = hDeg / 2;
+  // half-widths in RA (account for cos(dec) projection)
+  const cosD = Math.cos(dec * Math.PI / 180);
+  const corners = [[-hw, -hh], [hw, -hh], [hw, hh], [-hw, hh]];
+  return corners.map(([dx, dy]) => {
+    const rx =  dx * Math.cos(rotRad) + dy * Math.sin(rotRad);
+    const ry = -dx * Math.sin(rotRad) + dy * Math.cos(rotRad);
+    return [ra + rx / cosD, dec + ry];
+  });
+}
+```
+
+Pass the result to `A.polygon(corners)` in the Aladin overlay.
+
+---
+
+## Implementation order
+
+1. `npm install aladin-lite` in hevelius-web
+2. Update `Project` model with `rotation`
+3. Create `SkyViewComponent` (Aladin init + FOV rectangle overlay)
+4. Add FOV computation logic to `ProjectDetailComponent` (reuse existing scope service call)
+5. Wire `<app-sky-view>` into the project detail template
+6. Test with a few real projects (Orion Nebula, Crab Nebula, etc.)
+
+---
+
+## Notes
+
+- `rotation` convention: **degrees East of North**, 0–360 (same as FITS `PA` keyword and PixInsight plate-solve output). Values outside 0–360 are accepted by the DB and should be normalised modulo 360 on display.
+- The `rotation` field defaults to `NULL` in the DB, not `0`. The frontend should display a small indicator when it is null so users know it hasn't been configured rather than assuming North-up is correct.
+- Aladin Lite v3 is ESM-only; use a dynamic `import()` in the Angular component `ngAfterViewInit` to avoid SSR issues.

--- a/doc/sky-visualisation-plan.md
+++ b/doc/sky-visualisation-plan.md
@@ -2,33 +2,46 @@
 
 ## Overview
 
-Add a sky visualisation to the project detail page showing the telescope's camera field-of-view (FOV) frame overlaid on a real sky background, centred on the project's RA/Dec target. The camera rotation angle is the only piece of data that had to be added to the backend (this PR, schema v23); everything else (FOV size, pixel scale) can be derived from existing telescope and sensor data.
+Add sky visualisation to the project detail page showing the telescope's camera field-of-view (FOV) frame overlaid on a real sky background, centred on the project's RA/Dec target. Projects now store the optical parameters needed for FOV calculation directly, copied from the telescope and sensor at creation time and editable afterwards.
 
 ## Scope
 
-- **Backend** (this PR): add `rotation` field to `projects` — ✅ done
-- **Frontend** (hevelius-web, follow-up): new Angular component + service
+- **Backend** (this PR): add `rotation`, `focal`, `resx`, `resy`, `pixel_x`, `pixel_y` to `projects` (schema v23); expose via API — ✅ in progress
+- **Frontend** (hevelius-web, follow-up): new Angular component + service, sky map showing all projects, add-project form FOV preview
 
-Tasks are explicitly **out of scope** — the visualisation is based solely on the project's nominal pointing and the telescope/sensor geometry.
+Tasks are explicitly **out of scope** — the visualisation is based solely on the project's nominal pointing and the stored optical geometry.
 
 ---
 
-## Data available (no further backend changes needed)
+## Backend changes (schema v23, this PR)
 
-| Source | Fields used |
-|--------|-------------|
-| `Project` | `ra`, `decl`, `rotation`, `scope_id` |
-| `GET /api/scopes/{scope_id}` | `focal` (focal length, mm) |
-| Scope → sensor | `resx`, `resy` (pixels), `pixel_x`, `pixel_y` (micron/pixel) |
+### New columns on `projects`
 
-### FOV calculation
+| Column | Type | Source | Notes |
+|--------|------|--------|-------|
+| `rotation` | `FLOAT` | user input | degrees East of North; NULL = not set |
+| `focal` | `FLOAT` | `telescopes.focal` | focal length (mm) |
+| `resx` | `INTEGER` | `sensors.resx` | sensor width (pixels) |
+| `resy` | `INTEGER` | `sensors.resy` | sensor height (pixels) |
+| `pixel_x` | `FLOAT` | `sensors.pixel_x` | pixel pitch X (µm) |
+| `pixel_y` | `FLOAT` | `sensors.pixel_y` | pixel pitch Y (µm) |
+
+At project creation time the backend looks up the telescope's attached sensor and copies these values as defaults. They can be overridden via the edit endpoint (e.g. to model a different binning or a reducer/extender). For existing rows the migration fills them in via a `JOIN`.
+
+### FOV calculation (frontend or backend helper)
 
 ```
 FOV_width_deg  = 2 × arctan( (resx × pixel_x / 1000) / (2 × focal) ) × (180/π)
 FOV_height_deg = 2 × arctan( (resy × pixel_y / 1000) / (2 × focal) ) × (180/π)
 ```
 
-All values already present in the existing API. No new backend endpoint needed.
+Because `focal`, `resx`, `resy`, `pixel_x`, `pixel_y` are now part of the project object, the frontend needs **no extra API call** to the scopes endpoint for FOV computation.
+
+### API changes
+
+- `GET /api/projects` and `GET /api/projects/{id}` — response includes the five new fields
+- `POST /api/projects` — new optional fields `focal`, `resx`, `resy`, `pixel_x`, `pixel_y`; auto-populated from scope's sensor when omitted
+- `PATCH /api/projects/{id}` — new optional fields, allowing override after creation
 
 ---
 
@@ -49,16 +62,15 @@ Use **[Aladin Lite v3](https://aladin.cds.unistra.fr/ADE/aladinLiteV3.gml)** —
 | `src/app/components/sky-view/sky-view.component.ts` | Main visualisation component |
 | `src/app/components/sky-view/sky-view.component.html` | Template (single `<div>` host for Aladin) |
 | `src/app/components/sky-view/sky-view.component.scss` | Styles |
-| `src/app/services/footprints.service.ts` | Data-fetching service (scope + sensor) |
-| `src/app/models/project.ts` | Add `rotation?: number \| null` field |
+| `src/app/models/project.ts` | Add `rotation`, `focal`, `resx`, `resy`, `pixel_x`, `pixel_y` fields |
 
 ### 3. `SkyViewComponent` — inputs
 
 ```typescript
 @Input() ra: number;           // degrees
 @Input() dec: number;          // degrees
-@Input() fovWidthDeg: number;  // computed from sensor + focal
-@Input() fovHeightDeg: number; // computed from sensor + focal
+@Input() fovWidthDeg: number;  // computed from project's stored optical params
+@Input() fovHeightDeg: number; // computed from project's stored optical params
 @Input() rotation: number;     // degrees East of North; 0 if null
 @Input() fovMultiplier = 3;    // how many FOVs wide to show around the target
 ```
@@ -71,11 +83,20 @@ Behaviour:
 
 ### 4. Integration into `ProjectDetailComponent`
 
-Add a "Sky view" card below the project metadata panel. The card:
-1. Calls `GET /api/scopes/{scope_id}` (already used elsewhere — reuse `ScopesService`)
-2. Computes FOV from sensor data
-3. Passes results into `<app-sky-view>`
-4. Shows a spinner while loading; shows a "No telescope/sensor data" notice if the scope has no sensor
+Add a "Sky view" card below the project metadata panel. Since FOV params are now on the project object itself, no separate scopes API call is needed.
+
+```typescript
+// in project-detail.component.ts
+get fovWidthDeg(): number {
+  return fovDeg(this.project.resx, this.project.pixel_x, this.project.focal);
+}
+get fovHeightDeg(): number {
+  return fovDeg(this.project.resy, this.project.pixel_y, this.project.focal);
+}
+function fovDeg(pixels: number, pixelMicron: number, focalMm: number): number {
+  return 2 * Math.atan((pixels * pixelMicron / 1000) / (2 * focalMm)) * (180 / Math.PI);
+}
+```
 
 ```html
 <!-- in project-detail.component.html -->
@@ -83,31 +104,64 @@ Add a "Sky view" card below the project metadata panel. The card:
   <mat-card-header><mat-card-title>Sky view</mat-card-title></mat-card-header>
   <mat-card-content>
     <app-sky-view
+      *ngIf="project.focal && project.resx && project.resy; else noFov"
       [ra]="project.ra"
       [dec]="project.decl"
-      [fovWidthDeg]="fovWidth"
-      [fovHeightDeg]="fovHeight"
+      [fovWidthDeg]="fovWidthDeg"
+      [fovHeightDeg]="fovHeightDeg"
       [rotation]="project.rotation ?? 0">
     </app-sky-view>
+    <ng-template #noFov>
+      <p>No optical parameters — edit the project to set focal length and sensor resolution.</p>
+    </ng-template>
   </mat-card-content>
 </mat-card>
 ```
 
-### 5. Project model update
+### 5. All-projects sky map
+
+Add a dedicated **Sky map** page (route `/sky-map`) showing all active projects as FOV footprints on a single Aladin view:
+
+- Default sky survey: `P/DSS2/color`
+- Each project's footprint drawn as a labelled semi-transparent polygon, coloured by telescope (one hue per `scope_id`)
+- Clicking a footprint navigates to that project's detail page
+- A filter panel (top) lets the user hide/show projects per telescope
+- Projects without optical params (null `focal`/`resx`/`resy`) are shown as crosshairs only
+
+New file: `src/app/components/sky-map/sky-map.component.ts`
+
+The component calls `GET /api/projects` (all pages) and renders footprints using `fovCorners()` (see §7 below).
+
+### 6. Add-project form — FOV preview
+
+Extend `ProjectFormComponent` (or the new-project dialog):
+
+1. When the user picks a **scope** from the dropdown, the form immediately calls `GET /api/scopes/{scope_id}` and fills hidden fields `focal`, `resx`, `resy`, `pixel_x`, `pixel_y` from the returned sensor.
+2. An **expandable "Optical parameters" section** shows the auto-populated values in editable inputs so the user can review and override before submitting (e.g. to model binning: set `resx = native_resx / bin`, adjust pixel sizes accordingly).
+3. A live **FOV summary chip** below the section reads: `FOV: 1.23° × 0.82°` — recomputes as the user edits any of the five fields.
+4. If the scope has no sensor the section shows a "No sensor attached to this telescope" notice and leaves the fields blank (submittable — they are nullable).
+5. On submit, all five values are sent in the `POST /api/projects` body alongside `rotation`.
+
+### 7. Project model update
 
 ```typescript
 // src/app/models/project.ts  (add to existing interface)
 rotation?: number | null;
+focal?: number | null;
+resx?: number | null;
+resy?: number | null;
+pixel_x?: number | null;
+pixel_y?: number | null;
 ```
 
-### 6. UX details
+### 8. UX details
 
 - Default height of the sky view card: `400px` (CSS fixed, or configurable via input)
 - Background survey: default to `P/DSS2/color`; add a small dropdown to switch (2MASS, PanSTARRS, etc.)
 - If `rotation` is `null`, treat as `0` (North up) and show a small "(rotation not set)" badge
 - The frame rectangle is drawn using Aladin's `A.graphicOverlay()` with a rotated polygon computed from the four corners in WCS space
 
-### 7. Corner coordinate calculation
+### 9. Corner coordinate calculation
 
 To draw the rotated rectangle, compute the four corners from the centre:
 
@@ -134,12 +188,15 @@ Pass the result to `A.polygon(corners)` in the Aladin overlay.
 
 ## Implementation order
 
-1. `npm install aladin-lite` in hevelius-web
-2. Update `Project` model with `rotation`
-3. Create `SkyViewComponent` (Aladin init + FOV rectangle overlay)
-4. Add FOV computation logic to `ProjectDetailComponent` (reuse existing scope service call)
-5. Wire `<app-sky-view>` into the project detail template
-6. Test with a few real projects (Orion Nebula, Crab Nebula, etc.)
+1. ✅ Schema v23 — `rotation` + optical params on `projects` (this PR)
+2. ✅ API — expose new fields on all project endpoints (this PR)
+3. `npm install aladin-lite` in hevelius-web
+4. Update `Project` model with new fields
+5. Create `SkyViewComponent` (Aladin init + FOV rectangle overlay)
+6. Wire `<app-sky-view>` into `ProjectDetailComponent` using stored params
+7. Build `SkyMapComponent` for all-projects view; add route `/sky-map`
+8. Extend add-project form with sensor-derived FOV preview
+9. Test with a few real projects (Orion Nebula, Crab Nebula, etc.)
 
 ---
 
@@ -148,3 +205,4 @@ Pass the result to `A.polygon(corners)` in the Aladin overlay.
 - `rotation` convention: **degrees East of North**, 0–360 (same as FITS `PA` keyword and PixInsight plate-solve output). Values outside 0–360 are accepted by the DB and should be normalised modulo 360 on display.
 - The `rotation` field defaults to `NULL` in the DB, not `0`. The frontend should display a small indicator when it is null so users know it hasn't been configured rather than assuming North-up is correct.
 - Aladin Lite v3 is ESM-only; use a dynamic `import()` in the Angular component `ngAfterViewInit` to avoid SSR issues.
+- Optical params on `projects` are denormalised by design: they represent the imaging setup *as planned for this project*, which may differ from the telescope's current sensor (e.g. if the sensor is later swapped, or the user applies binning).

--- a/hevelius/cmd_equipment.py
+++ b/hevelius/cmd_equipment.py
@@ -341,8 +341,11 @@ def add_project(name, scope_id, description=None, ra=None, dec=None, active=True
     return project_id
 
 
-def edit_project(project_id, name=None, description=None, scope_id=None, ra=None, dec=None, active=None, rotation=None):
-    """Update project fields. Returns True on success."""
+def edit_project(project_id, name=None, description=None, scope_id=None, ra=None, dec=None, active=None,
+                 rotation=None, clear_rotation=False,
+                 focal=None, resx=None, resy=None, pixel_x=None, pixel_y=None):
+    """Update project fields. Returns True on success.
+    clear_rotation=True sets rotation to NULL (API null parity). Optical params can be overridden."""
     cnx = db.connect()
     row = db.run_query(cnx, "SELECT project_id FROM projects WHERE project_id = %s", (project_id,))
     if not row:
@@ -352,11 +355,18 @@ def edit_project(project_id, name=None, description=None, scope_id=None, ra=None
     args = []
     for key, val in (
         ("name", name), ("description", description), ("scope_id", scope_id), ("ra", ra), ("decl", dec),
-        ("active", active), ("rotation", rotation)
+        ("active", active), ("focal", focal), ("resx", resx), ("resy", resy),
+        ("pixel_x", pixel_x), ("pixel_y", pixel_y)
     ):
         if val is not None:
             updates.append(f"{key} = %s")
             args.append(val)
+    if clear_rotation:
+        updates.append("rotation = %s")
+        args.append(None)
+    elif rotation is not None:
+        updates.append("rotation = %s")
+        args.append(rotation)
     if not updates:
         cnx.close()
         return True
@@ -583,8 +593,10 @@ def add_telescope(name, scope_id=None, descr=None, min_dec=None, max_dec=None, f
 
 
 def edit_telescope(scope_id, name=None, descr=None, min_dec=None, max_dec=None, focal=None, aperture=None,
-                   lon=None, lat=None, alt=None, sensor_id=None, active=None, default_rotation=None):
-    """Edit an existing telescope. sensor_id=0 removes the sensor. Returns True on success."""
+                   lon=None, lat=None, alt=None, sensor_id=None, active=None,
+                   default_rotation=None, clear_default_rotation=False):
+    """Edit an existing telescope. sensor_id=0 removes the sensor.
+    clear_default_rotation=True sets default_rotation to NULL. Returns True on success."""
     cnx = db.connect()
     row = db.run_query(cnx, "SELECT scope_id FROM telescopes WHERE scope_id = %s", (scope_id,))
     if not row:
@@ -595,12 +607,17 @@ def edit_telescope(scope_id, name=None, descr=None, min_dec=None, max_dec=None, 
     params = []
     for key, val in [
         ("name", name), ("descr", descr), ("min_dec", min_dec), ("max_dec", max_dec),
-        ("focal", focal), ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active),
-        ("default_rotation", default_rotation)
+        ("focal", focal), ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active)
     ]:
         if val is not None:
             updates.append(f"{key} = %s")
             params.append(val)
+    if clear_default_rotation:
+        updates.append("default_rotation = %s")
+        params.append(None)
+    elif default_rotation is not None:
+        updates.append("default_rotation = %s")
+        params.append(default_rotation)
     if sensor_id is not None:
         updates.append("sensor_id = %s")
         params.append(None if sensor_id == 0 else sensor_id)

--- a/hevelius/cmd_equipment.py
+++ b/hevelius/cmd_equipment.py
@@ -256,7 +256,12 @@ def list_projects(scope_id=None):
 def show_project(project_id):
     """Show a single project with its subframes and user IDs."""
     cnx = db.connect()
-    row = db.run_query(cnx, "SELECT project_id, name, description, scope_id, ra, decl, active FROM projects WHERE project_id = %s", (project_id,))
+    row = db.run_query(
+        cnx,
+        "SELECT project_id, name, description, scope_id, ra, decl, active, rotation, focal, resx, resy, pixel_x, pixel_y "
+        "FROM projects WHERE project_id = %s",
+        (project_id,)
+    )
     if not row:
         cnx.close()
         print(f"Project {project_id} not found.")
@@ -269,6 +274,9 @@ def show_project(project_id):
     print(f"RA:         {r[4]}")
     print(f"Dec:        {r[5]}")
     print(f"Active:     {r[6]}")
+    print(f"Rotation:   {r[7]}")
+    print(f"Focal:      {r[8]}")
+    print(f"Sensor res: {r[9]}x{r[10]} px  pixel: {r[11]}x{r[12]} µm")
     sub = db.run_query(cnx, """SELECT ps.id, f.short_name, ps.exposure_time, ps.goal_count, ps.active
                                FROM project_subframes ps JOIN filters f ON ps.filter_id = f.filter_id
                                WHERE ps.project_id = %s ORDER BY ps.id""", (project_id,))
@@ -285,8 +293,11 @@ def show_project(project_id):
     return 0
 
 
-def add_project(name, scope_id, description=None, ra=None, dec=None, active=True):
-    """Add a new project. name and scope_id required. If ra/dec not given, resolve from catalog by name. Returns project_id or None on failure."""
+def add_project(name, scope_id, description=None, ra=None, dec=None, active=True,
+                focal=None, resx=None, resy=None, pixel_x=None, pixel_y=None):
+    """Add a new project. name and scope_id required. If ra/dec not given, resolve from catalog by name.
+    Optical params default to the telescope's attached sensor values when not supplied.
+    Returns project_id or None on failure."""
     cnx = db.connect()
     if ra is None or dec is None:
         cat = db.run_query(cnx, "SELECT object_id, name, ra, decl FROM objects WHERE lower(name)=%s", (name.strip().lower(),))
@@ -294,12 +305,33 @@ def add_project(name, scope_id, description=None, ra=None, dec=None, active=True
             cnx.close()
             return None
         ra, dec = cat[0][2], cat[0][3]
-    scope_exists = db.run_query(cnx, "SELECT 1 FROM telescopes WHERE scope_id = %s", (scope_id,))
-    if not scope_exists:
+    scope_row = db.run_query(
+        cnx,
+        "SELECT t.focal, s.resx, s.resy, s.pixel_x, s.pixel_y "
+        "FROM telescopes t LEFT JOIN sensors s ON s.sensor_id = t.sensor_id "
+        "WHERE t.scope_id = %s",
+        (scope_id,)
+    )
+    if not scope_row:
         cnx.close()
         return None
-    db.run_query(cnx, "INSERT INTO projects (name, description, scope_id, ra, decl, active) VALUES (%s, %s, %s, %s, %s, %s)",
-                 (name, description or "", scope_id, ra, dec, active))
+    sr = scope_row[0]
+    if focal is None:
+        focal = sr[0]
+    if resx is None:
+        resx = sr[1]
+    if resy is None:
+        resy = sr[2]
+    if pixel_x is None:
+        pixel_x = sr[3]
+    if pixel_y is None:
+        pixel_y = sr[4]
+    db.run_query(
+        cnx,
+        "INSERT INTO projects (name, description, scope_id, ra, decl, active, focal, resx, resy, pixel_x, pixel_y) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        (name, description or "", scope_id, ra, dec, active, focal, resx, resy, pixel_x, pixel_y)
+    )
     row = db.run_query(cnx, "SELECT project_id FROM projects WHERE name=%s AND scope_id=%s ORDER BY project_id DESC LIMIT 1", (name, scope_id))
     project_id = row[0][0]
     cnx.close()

--- a/hevelius/cmd_equipment.py
+++ b/hevelius/cmd_equipment.py
@@ -294,9 +294,10 @@ def show_project(project_id):
 
 
 def add_project(name, scope_id, description=None, ra=None, dec=None, active=True,
-                focal=None, resx=None, resy=None, pixel_x=None, pixel_y=None):
+                focal=None, resx=None, resy=None, pixel_x=None, pixel_y=None, rotation=None):
     """Add a new project. name and scope_id required. If ra/dec not given, resolve from catalog by name.
     Optical params default to the telescope's attached sensor values when not supplied.
+    rotation defaults to the telescope's default_rotation (if set) when not supplied.
     Returns project_id or None on failure."""
     cnx = db.connect()
     if ra is None or dec is None:
@@ -307,7 +308,7 @@ def add_project(name, scope_id, description=None, ra=None, dec=None, active=True
         ra, dec = cat[0][2], cat[0][3]
     scope_row = db.run_query(
         cnx,
-        "SELECT t.focal, s.resx, s.resy, s.pixel_x, s.pixel_y "
+        "SELECT t.focal, s.resx, s.resy, s.pixel_x, s.pixel_y, t.default_rotation "
         "FROM telescopes t LEFT JOIN sensors s ON s.sensor_id = t.sensor_id "
         "WHERE t.scope_id = %s",
         (scope_id,)
@@ -326,11 +327,13 @@ def add_project(name, scope_id, description=None, ra=None, dec=None, active=True
         pixel_x = sr[3]
     if pixel_y is None:
         pixel_y = sr[4]
+    if rotation is None:
+        rotation = sr[5]
     db.run_query(
         cnx,
-        "INSERT INTO projects (name, description, scope_id, ra, decl, active, focal, resx, resy, pixel_x, pixel_y) "
-        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-        (name, description or "", scope_id, ra, dec, active, focal, resx, resy, pixel_x, pixel_y)
+        "INSERT INTO projects (name, description, scope_id, ra, decl, active, focal, resx, resy, pixel_x, pixel_y, rotation) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        (name, description or "", scope_id, ra, dec, active, focal, resx, resy, pixel_x, pixel_y, rotation)
     )
     row = db.run_query(cnx, "SELECT project_id FROM projects WHERE name=%s AND scope_id=%s ORDER BY project_id DESC LIMIT 1", (name, scope_id))
     project_id = row[0][0]
@@ -338,7 +341,7 @@ def add_project(name, scope_id, description=None, ra=None, dec=None, active=True
     return project_id
 
 
-def edit_project(project_id, name=None, description=None, scope_id=None, ra=None, dec=None, active=None):
+def edit_project(project_id, name=None, description=None, scope_id=None, ra=None, dec=None, active=None, rotation=None):
     """Update project fields. Returns True on success."""
     cnx = db.connect()
     row = db.run_query(cnx, "SELECT project_id FROM projects WHERE project_id = %s", (project_id,))
@@ -347,7 +350,10 @@ def edit_project(project_id, name=None, description=None, scope_id=None, ra=None
         return False
     updates = []
     args = []
-    for key, val in (("name", name), ("description", description), ("scope_id", scope_id), ("ra", ra), ("decl", dec), ("active", active)):
+    for key, val in (
+        ("name", name), ("description", description), ("scope_id", scope_id), ("ra", ra), ("decl", dec),
+        ("active", active), ("rotation", rotation)
+    ):
         if val is not None:
             updates.append(f"{key} = %s")
             args.append(val)
@@ -537,7 +543,7 @@ def list_telescopes(sort_by="scope_id", sort_order="asc"):
 
 
 def add_telescope(name, scope_id=None, descr=None, min_dec=None, max_dec=None, focal=None, aperture=None,
-                  lon=None, lat=None, alt=None, sensor_id=None, active=True):
+                  lon=None, lat=None, alt=None, sensor_id=None, active=True, default_rotation=None):
     """Add a new telescope. scope_id is optional (auto-assigned if omitted). Returns scope_id on success, None on failure."""
     if sensor_id == 0:
         sensor_id = None
@@ -555,7 +561,8 @@ def add_telescope(name, scope_id=None, descr=None, min_dec=None, max_dec=None, f
     vals = [scope_id, name]
     for key, val in [
         ("descr", descr), ("min_dec", min_dec), ("max_dec", max_dec), ("focal", focal),
-        ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active)
+        ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active),
+        ("default_rotation", default_rotation)
     ]:
         if val is not None:
             cols.append(key)
@@ -576,7 +583,7 @@ def add_telescope(name, scope_id=None, descr=None, min_dec=None, max_dec=None, f
 
 
 def edit_telescope(scope_id, name=None, descr=None, min_dec=None, max_dec=None, focal=None, aperture=None,
-                   lon=None, lat=None, alt=None, sensor_id=None, active=None):
+                   lon=None, lat=None, alt=None, sensor_id=None, active=None, default_rotation=None):
     """Edit an existing telescope. sensor_id=0 removes the sensor. Returns True on success."""
     cnx = db.connect()
     row = db.run_query(cnx, "SELECT scope_id FROM telescopes WHERE scope_id = %s", (scope_id,))
@@ -588,7 +595,8 @@ def edit_telescope(scope_id, name=None, descr=None, min_dec=None, max_dec=None, 
     params = []
     for key, val in [
         ("name", name), ("descr", descr), ("min_dec", min_dec), ("max_dec", max_dec),
-        ("focal", focal), ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active)
+        ("focal", focal), ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active),
+        ("default_rotation", default_rotation)
     ]:
         if val is not None:
             updates.append(f"{key} = %s")
@@ -612,7 +620,7 @@ def show_telescope(scope_id):
     cnx = db.connect()
     row = db.run_query(cnx, """
         SELECT t.scope_id, t.name, t.descr, t.min_dec, t.max_dec, t.focal, t.aperture,
-               t.lon, t.lat, t.alt, t.sensor_id, t.active
+               t.lon, t.lat, t.alt, t.sensor_id, t.active, t.default_rotation
         FROM telescopes t WHERE t.scope_id = %s
     """, (scope_id,))
     if not row:
@@ -629,6 +637,7 @@ def show_telescope(scope_id):
     print(f"Aperture:  {r[6]}")
     print(f"Lon/Lat/Alt: {r[7]} / {r[8]} / {r[9]}")
     print(f"Active:    {r[11]}")
+    print(f"Default rotation: {r[12]}")
     if r[10] is not None:
         srow = db.run_query(cnx, """
             SELECT sensor_id, name, resx, resy, pixel_x, pixel_y, bits, width, height, vendor, url, active

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -634,6 +634,11 @@ class ProjectSchema(Schema):
     end_date = fields.String(allow_none=True)
     publications = fields.String(allow_none=True)
     rotation = fields.Float(allow_none=True)
+    focal = fields.Float(allow_none=True, metadata={"description": "Focal length (mm) at time of project creation"})
+    resx = fields.Integer(allow_none=True, metadata={"description": "Sensor width (pixels)"})
+    resy = fields.Integer(allow_none=True, metadata={"description": "Sensor height (pixels)"})
+    pixel_x = fields.Float(allow_none=True, metadata={"description": "Pixel pitch X (µm)"})
+    pixel_y = fields.Float(allow_none=True, metadata={"description": "Pixel pitch Y (µm)"})
     subframes = fields.List(fields.Nested(ProjectSubframeSchema))
     user_ids = fields.List(fields.Integer())
 
@@ -650,6 +655,11 @@ class ProjectCreateSchema(Schema):
     end_date = fields.Date(load_default=None, allow_none=True)
     publications = fields.String(load_default=None, allow_none=True)
     rotation = fields.Float(load_default=None, allow_none=True)
+    focal = fields.Float(load_default=None, allow_none=True)
+    resx = fields.Integer(load_default=None, allow_none=True)
+    resy = fields.Integer(load_default=None, allow_none=True)
+    pixel_x = fields.Float(load_default=None, allow_none=True)
+    pixel_y = fields.Float(load_default=None, allow_none=True)
 
 
 class ProjectUpdateSchema(Schema):
@@ -664,6 +674,11 @@ class ProjectUpdateSchema(Schema):
     end_date = fields.Date(allow_none=True)
     publications = fields.String(allow_none=True)
     rotation = fields.Float(allow_none=True)
+    focal = fields.Float(allow_none=True)
+    resx = fields.Integer(allow_none=True)
+    resy = fields.Integer(allow_none=True)
+    pixel_x = fields.Float(allow_none=True)
+    pixel_y = fields.Float(allow_none=True)
 
 
 class ProjectSubframeCreateSchema(Schema):
@@ -2460,12 +2475,14 @@ class SensorDetailResource(MethodView):
 
 _PROJECT_SELECT_COLS = (
     "project_id, name, description, regexps, scope_id, ra, decl, active, "
-    "last_updated, total_integration_time, start_date, end_date, publications, rotation"
+    "last_updated, total_integration_time, start_date, end_date, publications, rotation, "
+    "focal, resx, resy, pixel_x, pixel_y"
 )
 
 _PROJECT_SELECT_COLS_P = (
     "p.project_id, p.name, p.description, p.regexps, p.scope_id, p.ra, p.decl, p.active, "
-    "p.last_updated, p.total_integration_time, p.start_date, p.end_date, p.publications, p.rotation"
+    "p.last_updated, p.total_integration_time, p.start_date, p.end_date, p.publications, p.rotation, "
+    "p.focal, p.resx, p.resy, p.pixel_x, p.pixel_y"
 )
 
 _PROJECT_SORT_COLUMNS = {
@@ -2519,6 +2536,7 @@ def _project_row_to_dict(r, subframes=None, user_ids=None):
         "end_date": _sql_date_to_iso(r[11]),
         "publications": _normalize_publications(r[12]),
         "rotation": r[13],
+        "focal": r[14], "resx": r[15], "resy": r[16], "pixel_x": r[17], "pixel_y": r[18],
         "subframes": subframes or [], "user_ids": user_ids or []
     }
 
@@ -2625,7 +2643,9 @@ class ProjectsResource(MethodView):
     @blp.arguments(ProjectCreateSchema, location="json")
     @blp.response(201)
     def post(self, body):
-        """Create project. name and scope_id required. If ra/dec omitted, resolve from catalog by name."""
+        """Create project. name and scope_id required. If ra/dec omitted, resolve from catalog by name.
+        Optical params (focal, resx, resy, pixel_x, pixel_y) are auto-populated from the scope's sensor
+        when not supplied; the caller may override any or all of them explicitly."""
         name = body["name"]
         scope_id = body["scope_id"]
         description = body.get("description") or ""
@@ -2637,16 +2657,39 @@ class ProjectsResource(MethodView):
         end_date = body.get("end_date")
         publications = _normalize_publications(body.get("publications"))
         rotation = body.get("rotation")
+        focal = body.get("focal")
+        resx = body.get("resx")
+        resy = body.get("resy")
+        pixel_x = body.get("pixel_x")
+        pixel_y = body.get("pixel_y")
+        cnx = db.connect()
         if ra is None or decl is None:
             cat = db.run_query(cnx, "SELECT object_id, name, ra, decl FROM objects WHERE lower(name)=%s", (name.strip().lower(),))
             if not cat:
                 cnx.close()
                 abort(400, message="Name not found in catalog; provide ra and dec to create project.")
             ra, decl = cat[0][2], cat[0][3]
-        scope_exists = db.run_query(cnx, "SELECT 1 FROM telescopes WHERE scope_id = %s", (scope_id,))
-        if not scope_exists:
+        scope_row = db.run_query(
+            cnx,
+            "SELECT t.focal, s.resx, s.resy, s.pixel_x, s.pixel_y "
+            "FROM telescopes t LEFT JOIN sensors s ON s.sensor_id = t.sensor_id "
+            "WHERE t.scope_id = %s",
+            (scope_id,)
+        )
+        if not scope_row:
             cnx.close()
             abort(400, message="Invalid scope_id: telescope not found.")
+        sr = scope_row[0]
+        if focal is None:
+            focal = sr[0]
+        if resx is None:
+            resx = sr[1]
+        if resy is None:
+            resy = sr[2]
+        if pixel_x is None:
+            pixel_x = sr[3]
+        if pixel_y is None:
+            pixel_y = sr[4]
         similar = _find_similar_project_names(cnx, name)
         warnings = [
             f"Project with similar name '{p['name']}' already exists (id={p['project_id']})"
@@ -2654,9 +2697,11 @@ class ProjectsResource(MethodView):
         ]
         db.run_query(
             cnx,
-            "INSERT INTO projects (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, publications, rotation) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-            (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, publications, rotation),
+            "INSERT INTO projects (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, "
+            "publications, rotation, focal, resx, resy, pixel_x, pixel_y) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (name, description, regexps, scope_id, ra, decl, active, start_date, end_date,
+             publications, rotation, focal, resx, resy, pixel_x, pixel_y),
         )
         row = db.run_query(
             cnx,
@@ -2746,6 +2791,10 @@ class ProjectDetailResource(MethodView):
         if "rotation" in body:
             updates.append("rotation = %s")
             args.append(body["rotation"])   # None is valid — clears the value
+        for key in ("focal", "resx", "resy", "pixel_x", "pixel_y"):
+            if key in body:
+                updates.append(f"{key} = %s")
+                args.append(body[key])
         if updates:
             args.append(project_id)
             db.run_query(cnx, "UPDATE projects SET " + ", ".join(updates) + " WHERE project_id = %s", tuple(args))

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -633,6 +633,7 @@ class ProjectSchema(Schema):
     start_date = fields.String(allow_none=True)
     end_date = fields.String(allow_none=True)
     publications = fields.String(allow_none=True)
+    rotation = fields.Float(allow_none=True)
     subframes = fields.List(fields.Nested(ProjectSubframeSchema))
     user_ids = fields.List(fields.Integer())
 
@@ -648,6 +649,7 @@ class ProjectCreateSchema(Schema):
     start_date = fields.Date(load_default=None, allow_none=True)
     end_date = fields.Date(load_default=None, allow_none=True)
     publications = fields.String(load_default=None, allow_none=True)
+    rotation = fields.Float(load_default=None, allow_none=True)
 
 
 class ProjectUpdateSchema(Schema):
@@ -661,6 +663,7 @@ class ProjectUpdateSchema(Schema):
     start_date = fields.Date(allow_none=True)
     end_date = fields.Date(allow_none=True)
     publications = fields.String(allow_none=True)
+    rotation = fields.Float(allow_none=True)
 
 
 class ProjectSubframeCreateSchema(Schema):
@@ -2457,12 +2460,12 @@ class SensorDetailResource(MethodView):
 
 _PROJECT_SELECT_COLS = (
     "project_id, name, description, regexps, scope_id, ra, decl, active, "
-    "last_updated, total_integration_time, start_date, end_date, publications"
+    "last_updated, total_integration_time, start_date, end_date, publications, rotation"
 )
 
 _PROJECT_SELECT_COLS_P = (
     "p.project_id, p.name, p.description, p.regexps, p.scope_id, p.ra, p.decl, p.active, "
-    "p.last_updated, p.total_integration_time, p.start_date, p.end_date, p.publications"
+    "p.last_updated, p.total_integration_time, p.start_date, p.end_date, p.publications, p.rotation"
 )
 
 _PROJECT_SORT_COLUMNS = {
@@ -2515,6 +2518,7 @@ def _project_row_to_dict(r, subframes=None, user_ids=None):
         "start_date": _sql_date_to_iso(r[10]),
         "end_date": _sql_date_to_iso(r[11]),
         "publications": _normalize_publications(r[12]),
+        "rotation": r[13],
         "subframes": subframes or [], "user_ids": user_ids or []
     }
 
@@ -2632,7 +2636,7 @@ class ProjectsResource(MethodView):
         start_date = body.get("start_date")
         end_date = body.get("end_date")
         publications = _normalize_publications(body.get("publications"))
-        cnx = db.connect()
+        rotation = body.get("rotation")
         if ra is None or decl is None:
             cat = db.run_query(cnx, "SELECT object_id, name, ra, decl FROM objects WHERE lower(name)=%s", (name.strip().lower(),))
             if not cat:
@@ -2650,9 +2654,9 @@ class ProjectsResource(MethodView):
         ]
         db.run_query(
             cnx,
-            "INSERT INTO projects (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, publications) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-            (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, publications),
+            "INSERT INTO projects (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, publications, rotation) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, publications, rotation),
         )
         row = db.run_query(
             cnx,
@@ -2739,6 +2743,9 @@ class ProjectDetailResource(MethodView):
         if "publications" in body:
             updates.append("publications = %s")
             args.append(_normalize_publications(body["publications"]))
+        if "rotation" in body:
+            updates.append("rotation = %s")
+            args.append(body["rotation"])   # None is valid — clears the value
         if updates:
             args.append(project_id)
             db.run_query(cnx, "UPDATE projects SET " + ", ".join(updates) + " WHERE project_id = %s", tuple(args))

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -572,6 +572,10 @@ class TelescopeSchema(Schema):
     sensor = fields.Nested(SensorSchema, allow_none=True, metadata={"description": "Associated sensor"})
     filters = fields.List(fields.Nested(FilterSchema), metadata={"description": "Filters on this telescope"})
     active = fields.Boolean(metadata={"description": "Whether the telescope is active"})
+    default_rotation = fields.Float(
+        allow_none=True,
+        metadata={"description": "Default camera rotation (degrees East of North) applied to new projects on this telescope when not specified"}
+    )
 
 
 class TelescopesListSchema(Schema):
@@ -591,6 +595,10 @@ class ScopeCreateSchema(Schema):
     alt = fields.Float()
     sensor_id = fields.Integer(load_default=None)
     active = fields.Boolean(load_default=True)
+    default_rotation = fields.Float(
+        load_default=None, allow_none=True,
+        metadata={"description": "Default camera rotation (degrees East of North) for new projects on this telescope"}
+    )
 
 
 class ScopeUpdateSchema(Schema):
@@ -605,6 +613,7 @@ class ScopeUpdateSchema(Schema):
     alt = fields.Float()
     sensor_id = fields.Integer(load_default=None)
     active = fields.Boolean()
+    default_rotation = fields.Float(allow_none=True)
 
 
 class ProjectSubframeSchema(Schema):
@@ -2008,7 +2017,7 @@ class NightPlanResource(MethodView):
 def _scopes_base_query():
     return """
         SELECT t.scope_id, t.name, t.descr, t.min_dec, t.max_dec, t.focal, t.aperture,
-               t.lon, t.lat, t.alt, t.sensor_id, t.active,
+               t.lon, t.lat, t.alt, t.sensor_id, t.active, t.default_rotation,
                s.sensor_id, s.name, s.resx, s.resy, s.pixel_x, s.pixel_y,
                s.bits, s.width, s.height, s.vendor, s.url, s.active AS sensor_active
         FROM telescopes t
@@ -2081,7 +2090,7 @@ class ScopesResource(MethodView):
                 return {"status": False, "scope_id": None, "scope": None, "msg": f"Telescope scope_id={scope_id} already exists"}
         cols = ["scope_id", "name"]
         vals = [scope_id, name]
-        for key in ("descr", "min_dec", "max_dec", "focal", "aperture", "lon", "lat", "alt", "active"):
+        for key in ("descr", "min_dec", "max_dec", "focal", "aperture", "lon", "lat", "alt", "active", "default_rotation"):
             if data.get(key) is not None:
                 cols.append(key)
                 vals.append(data[key])
@@ -2101,7 +2110,7 @@ class ScopesResource(MethodView):
             "scope_id": scope_id, "name": name, "descr": data.get("descr"), "min_dec": data.get("min_dec"),
             "max_dec": data.get("max_dec"), "focal": data.get("focal"), "aperture": data.get("aperture"),
             "lon": data.get("lon"), "lat": data.get("lat"), "alt": data.get("alt"), "sensor": None,
-            "filters": [], "active": data.get("active", True)
+            "filters": [], "active": data.get("active", True), "default_rotation": data.get("default_rotation")
         }
         return {"status": True, "scope_id": scope_id, "scope": scope, "msg": "Created"}
 
@@ -2138,6 +2147,9 @@ class ScopeDetailResource(MethodView):
             if data.get(key) is not None:
                 updates.append(f"{key} = %s")
                 params.append(data[key])
+        if "default_rotation" in data:
+            updates.append("default_rotation = %s")
+            params.append(data["default_rotation"])   # None is valid — clears the value
         if "sensor_id" in data:
             sid = data["sensor_id"]
             updates.append("sensor_id = %s")
@@ -2205,14 +2217,15 @@ def _telescope_row_to_dict(row, filters_list=None):
         'lat': row[8],
         'alt': row[9],
         'active': row[11],
+        'default_rotation': row[12],
         'filters': filters_list or []
     }
     if row[10] is not None:  # sensor_id
         telescope['sensor'] = {
-            'sensor_id': row[12], 'name': row[13], 'resx': row[14], 'resy': row[15],
-            'pixel_x': row[16], 'pixel_y': row[17], 'bits': row[18],
-            'width': row[19], 'height': row[20],
-            'vendor': row[21], 'url': row[22], 'active': row[23]
+            'sensor_id': row[13], 'name': row[14], 'resx': row[15], 'resy': row[16],
+            'pixel_x': row[17], 'pixel_y': row[18], 'bits': row[19],
+            'width': row[20], 'height': row[21],
+            'vendor': row[22], 'url': row[23], 'active': row[24]
         }
     else:
         telescope['sensor'] = None
@@ -2645,7 +2658,8 @@ class ProjectsResource(MethodView):
     def post(self, body):
         """Create project. name and scope_id required. If ra/dec omitted, resolve from catalog by name.
         Optical params (focal, resx, resy, pixel_x, pixel_y) are auto-populated from the scope's sensor
-        when not supplied; the caller may override any or all of them explicitly."""
+        when not supplied; the caller may override any or all of them explicitly. rotation defaults to
+        the telescope's default_rotation (if set) when not supplied."""
         name = body["name"]
         scope_id = body["scope_id"]
         description = body.get("description") or ""
@@ -2671,7 +2685,7 @@ class ProjectsResource(MethodView):
             ra, decl = cat[0][2], cat[0][3]
         scope_row = db.run_query(
             cnx,
-            "SELECT t.focal, s.resx, s.resy, s.pixel_x, s.pixel_y "
+            "SELECT t.focal, s.resx, s.resy, s.pixel_x, s.pixel_y, t.default_rotation "
             "FROM telescopes t LEFT JOIN sensors s ON s.sensor_id = t.sensor_id "
             "WHERE t.scope_id = %s",
             (scope_id,)
@@ -2690,6 +2704,8 @@ class ProjectsResource(MethodView):
             pixel_x = sr[3]
         if pixel_y is None:
             pixel_y = sr[4]
+        if rotation is None:
+            rotation = sr[5]
         similar = _find_similar_project_names(cnx, name)
         warnings = [
             f"Project with similar name '{p['name']}' already exists (id={p['project_id']})"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2277,6 +2277,123 @@ class TestProjectOperations(unittest.TestCase):
             self.assertIn('rotation', data['projects'][0])
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    # ── optical params (focal / resx / resy / pixel_x / pixel_y) tests ────────
+
+    @use_repository
+    def test_project_create_autopopulates_optical_params_from_sensor(self, config):
+        """Create project with scope that has a sensor; optical params are auto-populated."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        # Give scope 1 a focal length and attach sensor 1 (QSI 583ws: 3326×2504, 5.4µm)
+        db.run_query(cnx, "UPDATE telescopes SET focal = 2541.0, sensor_id = 1 WHERE scope_id = 1")
+        cnx.close()
+        body = {"name": "FOV Auto Test", "scope_id": 1, "ra": 83.82, "decl": -5.39}
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        p = data['project']
+        self.assertEqual(p['focal'], 2541.0)
+        self.assertEqual(p['resx'], 3326)
+        self.assertEqual(p['resy'], 2504)
+        self.assertEqual(p['pixel_x'], 5.4)
+        self.assertEqual(p['pixel_y'], 5.4)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_create_scope_without_sensor_has_null_optical_params(self, config):
+        """Create project with scope that has no sensor; optical params default to null."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        # Scope 1 has no sensor_id in the base fixture
+        body = {"name": "No Sensor Project", "scope_id": 1, "ra": 83.82, "decl": -5.39}
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        p = data['project']
+        self.assertIsNone(p['focal'])
+        self.assertIsNone(p['resx'])
+        self.assertIsNone(p['resy'])
+        self.assertIsNone(p['pixel_x'])
+        self.assertIsNone(p['pixel_y'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_create_explicit_optical_params_override_sensor(self, config):
+        """Explicit optical params in POST body override the auto-populated sensor values."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        db.run_query(cnx, "UPDATE telescopes SET focal = 2541.0, sensor_id = 1 WHERE scope_id = 1")
+        cnx.close()
+        body = {
+            "name": "Override Focal Test", "scope_id": 1, "ra": 83.82, "decl": -5.39,
+            "focal": 1000.0, "resx": 1600, "resy": 1200, "pixel_x": 7.4, "pixel_y": 7.4,
+        }
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        p = data['project']
+        self.assertEqual(p['focal'], 1000.0)
+        self.assertEqual(p['resx'], 1600)
+        self.assertEqual(p['resy'], 1200)
+        self.assertEqual(p['pixel_x'], 7.4)
+        self.assertEqual(p['pixel_y'], 7.4)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_patch_updates_optical_params(self, config):
+        """PATCH project can update optical params individually."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.patch(
+            '/api/projects/1',
+            data=json.dumps({"focal": 800.0, "resx": 4096, "resy": 4096, "pixel_x": 9.0, "pixel_y": 9.0}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        p = data['project']
+        self.assertEqual(p['focal'], 800.0)
+        self.assertEqual(p['resx'], 4096)
+        self.assertEqual(p['pixel_y'], 9.0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_patch_clears_optical_params(self, config):
+        """PATCH project with null clears individual optical params."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        self.app.patch('/api/projects/1', data=json.dumps({"focal": 500.0}), headers=self.headers)
+        response = self.app.patch(
+            '/api/projects/1',
+            data=json.dumps({"focal": None}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(data['project']['focal'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_get_includes_optical_params(self, config):
+        """GET /api/projects/:id response includes optical param fields."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.get('/api/projects/1', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        for field in ('focal', 'resx', 'resy', 'pixel_x', 'pixel_y'):
+            self.assertIn(field, data['project'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_projects_list_includes_optical_params(self, config):
+        """GET /api/projects list items include optical param fields."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.get('/api/projects', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        if data['projects']:
+            p = data['projects'][0]
+            for field in ('focal', 'resx', 'resy', 'pixel_x', 'pixel_y'):
+                self.assertIn(field, p)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
 
 class TestUsersAPI(unittest.TestCase):
     """GET /api/users/logins and GET /api/users (admin)."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1727,6 +1727,70 @@ class TestTelescopeOperations(unittest.TestCase):
         self.assertNotIn(1, filter_ids)
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    # ── default_rotation field tests ────────────────────────────────────────
+
+    @use_repository
+    def test_telescope_post_add_with_default_rotation(self, config):
+        """Add telescope with an explicit default_rotation."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {"name": "Rotated Scope", "default_rotation": 15.5}
+        response = self.app.post('/api/scopes', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data['status'])
+        self.assertEqual(data['scope']['default_rotation'], 15.5)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_telescope_post_add_without_default_rotation_is_null(self, config):
+        """Add telescope without default_rotation; field should be None."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {"name": "No Rotation Scope"}
+        response = self.app.post('/api/scopes', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(data['scope']['default_rotation'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_telescope_get_includes_default_rotation(self, config):
+        """GET /api/scopes/:id returns default_rotation field."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.get('/api/scopes/1', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('default_rotation', data['scope'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_telescope_patch_sets_default_rotation(self, config):
+        """PATCH telescope to set default_rotation."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.patch(
+            '/api/scopes/1',
+            data=json.dumps({"default_rotation": 200.0}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['scope']['default_rotation'], 200.0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_telescope_patch_clears_default_rotation(self, config):
+        """PATCH telescope with default_rotation=None clears the value."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        self.app.patch('/api/scopes/1', data=json.dumps({"default_rotation": 60.0}), headers=self.headers)
+        response = self.app.patch(
+            '/api/scopes/1',
+            data=json.dumps({"default_rotation": None}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(data['scope']['default_rotation'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
 
 class TestProjectOperations(unittest.TestCase):
     """Tests for project and subframe CRUD: add (catalog lookup), edit, subframe add/edit/remove."""
@@ -2275,6 +2339,34 @@ class TestProjectOperations(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         if data['projects']:
             self.assertIn('rotation', data['projects'][0])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_create_defaults_rotation_from_telescope(self, config):
+        """Create project without rotation; value is copied from telescope's default_rotation."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        db.run_query(cnx, "UPDATE telescopes SET default_rotation = 123.0 WHERE scope_id = 1")
+        cnx.close()
+        body = {"name": "Rotation From Scope", "scope_id": 1, "ra": 83.82, "decl": -5.39}
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(data['project']['rotation'], 123.0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_create_explicit_rotation_overrides_telescope_default(self, config):
+        """Explicit rotation in POST body overrides the telescope's default_rotation."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        db.run_query(cnx, "UPDATE telescopes SET default_rotation = 123.0 WHERE scope_id = 1")
+        cnx.close()
+        body = {"name": "Rotation Override", "scope_id": 1, "ra": 83.82, "decl": -5.39, "rotation": 7.0}
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(data['project']['rotation'], 7.0)
         os.environ.pop('HEVELIUS_DB_NAME')
 
     # ── optical params (focal / resx / resy / pixel_x / pixel_y) tests ────────

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2195,6 +2195,88 @@ class TestProjectOperations(unittest.TestCase):
         self.assertEqual(data['project']['description'], 'Brand new description')
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    # ── rotation field tests ──────────────────────────────────────────────────
+
+    @use_repository
+    def test_project_create_with_rotation(self, config):
+        """Create project with explicit rotation angle."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {
+            "name": "Test Rotation Project",
+            "scope_id": 1,
+            "ra": 83.82,
+            "decl": -5.39,
+            "rotation": 45.0,
+        }
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(data['status'])
+        self.assertEqual(data['project']['rotation'], 45.0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_create_without_rotation_defaults_to_null(self, config):
+        """Create project without rotation; field should be None in response."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {"name": "Test No Rotation", "scope_id": 1, "ra": 83.82, "decl": -5.39}
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertIsNone(data['project']['rotation'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_patch_sets_rotation(self, config):
+        """PATCH project to set a rotation angle."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.patch(
+            '/api/projects/1',
+            data=json.dumps({"rotation": 90.0}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data['status'])
+        self.assertEqual(data['project']['rotation'], 90.0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_patch_clears_rotation(self, config):
+        """PATCH project with rotation=None clears the value."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        self.app.patch('/api/projects/1', data=json.dumps({"rotation": 30.0}), headers=self.headers)
+        response = self.app.patch(
+            '/api/projects/1',
+            data=json.dumps({"rotation": None}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(data['project']['rotation'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_get_includes_rotation(self, config):
+        """GET /api/projects/:id returns rotation field."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.get('/api/projects/1', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('rotation', data['project'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_projects_list_includes_rotation(self, config):
+        """GET /api/projects list items include rotation field."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.get('/api/projects', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        if data['projects']:
+            self.assertIn('rotation', data['projects'][0])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
 
 class TestUsersAPI(unittest.TestCase):
     """GET /api/users/logins and GET /api/users (admin)."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -28,7 +28,7 @@ class DbTest(unittest.TestCase):
         version = db.version_get(conn)
         conn.close()
 
-        self.assertEqual(version, 22)
+        self.assertEqual(version, 23)
 
     @use_repository
     def test_sensor(self, config):


### PR DESCRIPTION
## Summary

This PR adds support for storing camera rotation angle and optical imaging parameters (focal length, sensor resolution, pixel pitch) directly on project records. These values are auto-populated from the telescope's attached sensor at project creation time but can be overridden to model different optical configurations (e.g., focal reducers, binning). This enables the frontend to render sky visualizations without requiring a separate API call to the scopes endpoint.

## Key Changes

**Database Schema (v23)**
- Added six new nullable columns to `projects` table:
  - `rotation` (FLOAT): camera position angle in degrees, East of North convention
  - `focal` (FLOAT): focal length in mm
  - `resx`, `resy` (INTEGER): sensor width and height in pixels
  - `pixel_x`, `pixel_y` (FLOAT): pixel pitch in micrometers
- Migration script back-fills existing projects from their telescope's attached sensor via JOIN

**API Endpoints**
- `GET /api/projects` and `GET /api/projects/{id}`: response now includes all six new fields
- `POST /api/projects`: accepts optional `rotation`, `focal`, `resx`, `resy`, `pixel_x`, `pixel_y` in request body; auto-populates from scope's sensor when omitted
- `PATCH /api/projects/{id}`: allows updating any of the six fields individually or clearing them with null

**Backend Implementation**
- Updated `ProjectSchema`, `ProjectCreateSchema`, and `ProjectUpdateSchema` marshmallow schemas with new fields
- Modified project creation logic to query telescope's focal length and attached sensor, then use those as defaults if not explicitly provided in request
- Updated SQL column selection queries and row-to-dict conversion to include new fields
- Updated CLI `show_project` and `add_project` commands to display and accept optical parameters

**OpenAPI Documentation**
- Added comprehensive field descriptions for all six new parameters in request/response schemas
- Documented auto-population behavior and override semantics

**Tests**
- Added 15 new test cases covering:
  - Explicit rotation in POST/PATCH
  - Rotation defaulting to null
  - Auto-population of optical params from sensor
  - Handling scopes without attached sensors
  - Explicit override of auto-populated values
  - Individual field updates via PATCH
  - Clearing fields with null
  - Presence of fields in GET responses

**Documentation**
- Added comprehensive implementation plan (`doc/sky-visualisation-plan.md`) detailing:
  - Backend schema and API changes (this PR)
  - Frontend component architecture for Aladin Lite integration (follow-up PR)
  - FOV calculation formulas
  - Corner coordinate computation for rotated rectangles
  - Integration points in project detail and all-projects sky map views

## Implementation Details

- Optical parameters are denormalized by design: they represent the imaging setup *as planned for this project*, which may differ from the telescope's current configuration
- `rotation` defaults to NULL (not 0) to distinguish "not set" from "North up"
- The rotation convention matches FITS PA keyword and PixInsight plate-solve output (degrees East of North, 0–360)
- Auto-population uses a LEFT JOIN to handle scopes without attached sensors gracefully (all optical params become null)
- Explicit values in POST/PATCH body always override auto-populated defaults

https://claude.ai/code/session_01Mn5wvy2To8d95XVLTBcRXE