### PR TITLE
Add asteroid search and detail API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 ## 0.6.0 (unreleased)
 - DB: schema bumped to 22: asteroids data now available.
 - DB: schema bumped to 23: camera rotation, camera details in the projects.
+- DB: schema bumped to 24: asteroid tags (many-to-many).
 - API: The telescopes now have a default camera rotation. The projects now have camera rotation.
   If not specified, the default from the telescope is copied.
 - CLI: It's possible to specify default rotation for a telescope, and an image rotation for
   a project.
+- CLI: `hevelius asteroid download` skips MPC when the local cache is younger than 7 days
+  (prints the reason); use `--force` to re-download. Download failures are logged clearly.
+- CLI: `hevelius asteroid status` reports MPCORB cache location/age and DB asteroid counters.
+- CLI: `hevelius asteroid load` upserts orbital elements from the cached MPCORB file into the DB.
 
 ## 0.5.1 (2026-05-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 - DB: schema bumped to 22: asteroids data now available.
 - DB: schema bumped to 23: camera rotation, camera details in the projects.
 - DB: schema bumped to 24: asteroid tags (`asteroid_tags`, `asteroid_tag_map`) for
-  families / NEO / PHA / etc., with list filtering by tag (`any` / `all`).
+  families / NEO / PHA / etc., with list filtering by tag (`any` / `all`); asteroids
+  gain optional proper `name` (from MPCORB readable designation).
 - API: asteroid list/detail (`GET`/`POST /api/asteroids`, `GET /api/asteroids/{id}`),
   per-asteroid night visibility curve (`GET /api/asteroids/{id}/visibility`), and
-  tag CRUD plus attach/detach endpoints.
+  tag CRUD plus attach/detach endpoints. List/detail expose `name`; list accepts
+  `name` filter and `sort_by=name`.
 - CLI: asteroid download/load from MPCORB and bulk night visibility listing.
+- CLI: `hevelius asteroid show <query>` looks up by proper name, MPC number, or
+  packed designation and prints a detailed (optionally colored) summary.
 - Fix: MPCORB permanent-number unpacking (plain, letter-coded, and tilde/base-62 forms).
 - API: The telescopes now have a default camera rotation. The projects now have camera rotation.
   If not specified, the default from the telescope is copied.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 - CLI: asteroid download/load from MPCORB and bulk night visibility listing.
 - CLI: `hevelius asteroid show <query>` looks up by proper name, MPC number, or
   packed designation and prints a detailed (optionally colored) summary.
+  With `--telescope` / `--telescope-id`, also prints a night altitude chart for
+  that site (`--date`, `--step-minutes` optional), including sunset/sunrise and
+  moonrise/moonset; chart markers are yellow while the Moon is above the horizon.
 - Fix: MPCORB permanent-number unpacking (plain, letter-coded, and tilde/base-62 forms).
 - API: The telescopes now have a default camera rotation. The projects now have camera rotation.
   If not specified, the default from the telescope is copied.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
   tag CRUD plus attach/detach endpoints. List/detail expose `name`; list accepts
   `name` filter and `sort_by=name`.
 - CLI: asteroid download/load from MPCORB and bulk night visibility listing.
+- CLI: `hevelius asteroid list` prints catalogue rows (default: first 100 by
+  increasing MPC number) with `--sort-by` / `--sort-order` and filters for name,
+  designation, number, numbered/unnumbered, H magnitude range, and tags.
 - CLI: `hevelius asteroid show <query>` looks up by proper name, MPC number, or
   packed designation and prints a detailed (optionally colored) summary.
   With `--telescope` / `--telescope-id`, also prints a night altitude chart for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 ## 0.6.0 (unreleased)
 - DB: schema bumped to 22: asteroids data now available.
 - DB: schema bumped to 23: camera rotation, camera details in the projects.
-- DB: schema bumped to 24: asteroid tags (many-to-many).
+- DB: schema bumped to 24: asteroid tags (`asteroid_tags`, `asteroid_tag_map`) for
+  families / NEO / PHA / etc., with list filtering by tag (`any` / `all`).
+- API: asteroid list/detail (`GET`/`POST /api/asteroids`, `GET /api/asteroids/{id}`),
+  per-asteroid night visibility curve (`GET /api/asteroids/{id}/visibility`), and
+  tag CRUD plus attach/detach endpoints.
+- CLI: asteroid download/load from MPCORB and bulk night visibility listing.
+- Fix: MPCORB permanent-number unpacking (plain, letter-coded, and tilde/base-62 forms).
 - API: The telescopes now have a default camera rotation. The projects now have camera rotation.
   If not specified, the default from the telescope is copied.
 - CLI: It's possible to specify default rotation for a telescope, and an image rotation for

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1056,7 +1056,10 @@ components:
           description: Display color (e.g. "#1976d2")
         asteroid_count:
           type: integer
-          description: Number of asteroids carrying this tag
+          description: >
+            Number of asteroids carrying this tag. Present on tag vocabulary
+            endpoints (list/create/get/patch); omitted when tags are embedded
+            on asteroid list/detail responses.
     AsteroidTagsList:
       type: object
       properties:
@@ -1192,7 +1195,9 @@ components:
           nullable: true
         visible:
           type: boolean
-          description: Whether the asteroid rises above the horizon during the night
+          description: >
+            True if max altitude during the night is above the geometric horizon
+            (altitude > 0°); no airmass or site horizon mask is applied
         has_magnitude_estimate:
           type: boolean
           description: Whether absolute_magnitude (H) was available
@@ -3404,7 +3409,9 @@ paths:
       description: >-
         Computes altitude, azimuth, and (if absolute magnitude H is known) estimated apparent
         magnitude across a night for one asteroid as seen from a telescope's location.
-        Defaults to tonight; pass `date` to check a different night.
+        Defaults to the server's local calendar date (not the telescope site's timezone);
+        pass `date` to check a different evening. `visible` means max altitude > 0°
+        (geometric horizon only). Smaller `step_minutes` values are more CPU-intensive.
       parameters:
         - name: asteroid_id
           in: path
@@ -3419,14 +3426,17 @@ paths:
             type: integer
         - name: date
           in: query
-          description: Evening date (YYYY-MM-DD) whose night to compute; defaults to tonight
+          description: >
+            Evening date (YYYY-MM-DD) whose night to compute; defaults to the server's
+            local calendar date (not the telescope site's timezone)
           required: false
           schema:
             type: string
             format: date
         - name: step_minutes
           in: query
-          description: Sampling interval across the night, in minutes
+          description: >
+            Sampling interval across the night, in minutes (smaller steps are more CPU-heavy)
           required: false
           schema:
             type: integer
@@ -3449,7 +3459,10 @@ paths:
   /api/asteroid-tags:
     get:
       summary: List asteroid tags
-      description: Returns all asteroid tags with the number of asteroids carrying each
+      description: >
+        Returns all asteroid tags with the number of asteroids carrying each.
+        Tag vocabulary is shared across the deployment; any authenticated user
+        may create, edit, delete, or attach tags.
       responses:
         '200':
           description: List of tags
@@ -3461,7 +3474,9 @@ paths:
         - bearerAuth: []
     post:
       summary: Create asteroid tag
-      description: Creates a new asteroid tag (e.g. amor, neo, pha, fast rotator, visited by spacecraft)
+      description: >
+        Creates a new asteroid tag (e.g. amor, neo, pha, fast rotator, visited by spacecraft).
+        Any authenticated user may create tags (shared catalogue vocabulary).
       requestBody:
         required: true
         content:
@@ -3501,7 +3516,10 @@ paths:
         - bearerAuth: []
     patch:
       summary: Edit asteroid tag
-      description: Partial update of an asteroid tag's name, description, or color
+      description: >
+        Partial update of an asteroid tag's name, description, or color.
+        Omit a field to leave it unchanged; send null for description/color to clear it.
+        Any authenticated user may edit tags (shared catalogue vocabulary).
       parameters:
         - name: tag_id
           in: path
@@ -3528,7 +3546,9 @@ paths:
         - bearerAuth: []
     delete:
       summary: Delete asteroid tag
-      description: Deletes the tag definition and removes it from any asteroids carrying it
+      description: >
+        Deletes the tag definition and removes it from any asteroids carrying it.
+        Any authenticated user may delete tags (shared catalogue vocabulary).
       parameters:
         - name: tag_id
           in: path
@@ -3542,12 +3562,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusMsg'
+        '404':
+          description: Tag not found
       security:
         - bearerAuth: []
   /api/asteroids/{asteroid_id}/tags:
     post:
       summary: Attach tag to asteroid
-      description: Attaches an existing asteroid tag to an asteroid (no-op if already attached)
+      description: >
+        Attaches an existing asteroid tag to an asteroid (no-op if already attached).
+        Any authenticated user may attach tags (shared catalogue vocabulary).
       parameters:
         - name: asteroid_id
           in: path
@@ -3567,17 +3591,21 @@ paths:
                   description: Tag ID to attach
       responses:
         '200':
-          description: Tag attached (or asteroid/tag not found, see status/msg)
+          description: Tag attached
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusMsg'
+        '404':
+          description: Asteroid or tag not found
       security:
         - bearerAuth: []
   /api/asteroids/{asteroid_id}/tags/{tag_id}:
     delete:
       summary: Detach tag from asteroid
-      description: Detaches a tag from an asteroid (no-op if not attached)
+      description: >
+        Detaches a tag from an asteroid (no-op if not attached).
+        Any authenticated user may detach tags (shared catalogue vocabulary).
       parameters:
         - name: asteroid_id
           in: path

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1032,6 +1032,87 @@ components:
           format: float
           nullable: true
           description: Phase slope parameter G
+        tags:
+          type: array
+          description: Tags attached to this asteroid
+          items:
+            $ref: '#/components/schemas/AsteroidTag'
+    AsteroidTag:
+      type: object
+      properties:
+        tag_id:
+          type: integer
+          description: Tag ID
+        name:
+          type: string
+          description: Tag name (e.g. amor, neo, pha)
+        description:
+          type: string
+          nullable: true
+          description: Tag description
+        color:
+          type: string
+          nullable: true
+          description: Display color (e.g. "#1976d2")
+        asteroid_count:
+          type: integer
+          description: Number of asteroids carrying this tag
+    AsteroidTagsList:
+      type: object
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/AsteroidTag'
+    AsteroidTagCreate:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          maxLength: 256
+          nullable: true
+        color:
+          type: string
+          maxLength: 16
+          nullable: true
+    AsteroidTagUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          maxLength: 256
+          nullable: true
+        color:
+          type: string
+          maxLength: 16
+          nullable: true
+    AsteroidTagCreateResponse:
+      type: object
+      properties:
+        status:
+          type: boolean
+        tag_id:
+          type: integer
+        tag:
+          $ref: '#/components/schemas/AsteroidTag'
+        msg:
+          type: string
+    AsteroidTagResponse:
+      type: object
+      properties:
+        status:
+          type: boolean
+        tag:
+          $ref: '#/components/schemas/AsteroidTag'
+        msg:
+          type: string
     AsteroidsList:
       type: object
       properties:
@@ -3147,6 +3228,20 @@ paths:
           schema:
             type: number
             format: float
+        - name: tags
+          in: query
+          description: Comma-separated tag names to filter by (e.g. "neo,pha")
+          required: false
+          schema:
+            type: string
+        - name: tags_mode
+          in: query
+          description: "'any': match asteroids with at least one listed tag (default); 'all': require every listed tag"
+          required: false
+          schema:
+            type: string
+            enum: [any, all]
+            default: any
       responses:
         '200':
           description: List of asteroids with pagination info
@@ -3206,6 +3301,14 @@ paths:
                   type: number
                   format: float
                   description: Maximum absolute magnitude (H)
+                tags:
+                  type: string
+                  description: Comma-separated tag names to filter by (e.g. "neo,pha")
+                tags_mode:
+                  type: string
+                  description: "'any': match asteroids with at least one listed tag (default); 'all': require every listed tag"
+                  enum: [any, all]
+                  default: any
       responses:
         '200':
           description: List of asteroids with pagination info
@@ -3236,5 +3339,157 @@ paths:
                 $ref: '#/components/schemas/AsteroidResponse'
         '404':
           description: Asteroid not found
+      security:
+        - bearerAuth: []
+  /api/asteroid-tags:
+    get:
+      summary: List asteroid tags
+      description: Returns all asteroid tags with the number of asteroids carrying each
+      responses:
+        '200':
+          description: List of tags
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsteroidTagsList'
+      security:
+        - bearerAuth: []
+    post:
+      summary: Create asteroid tag
+      description: Creates a new asteroid tag (e.g. amor, neo, pha, fast rotator, visited by spacecraft)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AsteroidTagCreate'
+      responses:
+        '200':
+          description: Tag created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsteroidTagCreateResponse'
+        '400':
+          description: Bad request (e.g. duplicate tag name)
+      security:
+        - bearerAuth: []
+  /api/asteroid-tags/{tag_id}:
+    get:
+      summary: Get asteroid tag details
+      parameters:
+        - name: tag_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Tag details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsteroidTagResponse'
+        '404':
+          description: Tag not found
+      security:
+        - bearerAuth: []
+    patch:
+      summary: Edit asteroid tag
+      description: Partial update of an asteroid tag's name, description, or color
+      parameters:
+        - name: tag_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AsteroidTagUpdate'
+      responses:
+        '200':
+          description: Tag updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsteroidTagResponse'
+        '400':
+          description: Bad request (e.g. duplicate tag name)
+        '404':
+          description: Tag not found
+      security:
+        - bearerAuth: []
+    delete:
+      summary: Delete asteroid tag
+      description: Deletes the tag definition and removes it from any asteroids carrying it
+      parameters:
+        - name: tag_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Tag deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusMsg'
+      security:
+        - bearerAuth: []
+  /api/asteroids/{asteroid_id}/tags:
+    post:
+      summary: Attach tag to asteroid
+      description: Attaches an existing asteroid tag to an asteroid (no-op if already attached)
+      parameters:
+        - name: asteroid_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tag_id]
+              properties:
+                tag_id:
+                  type: integer
+                  description: Tag ID to attach
+      responses:
+        '200':
+          description: Tag attached (or asteroid/tag not found, see status/msg)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusMsg'
+      security:
+        - bearerAuth: []
+  /api/asteroids/{asteroid_id}/tags/{tag_id}:
+    delete:
+      summary: Detach tag from asteroid
+      description: Detaches a tag from an asteroid (no-op if not attached)
+      parameters:
+        - name: asteroid_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: tag_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Tag detached
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusMsg'
       security:
         - bearerAuth: []

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -978,6 +978,88 @@ components:
           $ref: '#/components/schemas/Telescope'
         msg:
           type: string
+    Asteroid:
+      type: object
+      properties:
+        asteroid_id:
+          type: integer
+          description: Asteroid ID
+        number:
+          type: integer
+          nullable: true
+          description: MPC number (null for unnumbered/provisional objects)
+        designation:
+          type: string
+          description: Packed MPC designation
+        epoch:
+          type: string
+          description: Epoch in MPC packed format
+        mean_anomaly:
+          type: number
+          format: float
+          description: Mean anomaly M at epoch (degrees)
+        perihelion_arg:
+          type: number
+          format: float
+          description: Argument of perihelion omega (degrees)
+        ascending_node:
+          type: number
+          format: float
+          description: Longitude of ascending node Omega (degrees)
+        inclination:
+          type: number
+          format: float
+          description: Orbital inclination i (degrees)
+        eccentricity:
+          type: number
+          format: float
+          description: Eccentricity e
+        mean_motion:
+          type: number
+          format: float
+          description: Mean daily motion n (degrees/day)
+        semimajor_axis:
+          type: number
+          format: float
+          description: Semi-major axis a (AU)
+        absolute_magnitude:
+          type: number
+          format: float
+          nullable: true
+          description: Absolute magnitude H
+        slope_parameter:
+          type: number
+          format: float
+          nullable: true
+          description: Phase slope parameter G
+    AsteroidsList:
+      type: object
+      properties:
+        asteroids:
+          type: array
+          items:
+            $ref: '#/components/schemas/Asteroid'
+        total:
+          type: integer
+          description: Total number of asteroids
+        page:
+          type: integer
+          description: Current page number
+        per_page:
+          type: integer
+          description: Items per page
+        pages:
+          type: integer
+          description: Total number of pages
+    AsteroidResponse:
+      type: object
+      properties:
+        status:
+          type: boolean
+        asteroid:
+          $ref: '#/components/schemas/Asteroid'
+        msg:
+          type: string
     Catalog:
       type: object
       properties:
@@ -2993,5 +3075,166 @@ paths:
                 $ref: '#/components/schemas/ObjectsList'
         '422':
           description: Invalid parameters (e.g. ra without decl)
+      security:
+        - bearerAuth: []
+  /api/asteroids:
+    get:
+      summary: Get list of asteroids
+      description: Returns a paginated list of asteroids (minor planets) with sorting and filtering options
+      parameters:
+        - name: page
+          in: query
+          description: Page number (starting from 1)
+          required: false
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - name: per_page
+          in: query
+          description: Number of items per page
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 1000
+        - name: sort_by
+          in: query
+          description: Field to sort by
+          required: false
+          schema:
+            type: string
+            enum: [number, designation, absolute_magnitude, semimajor_axis, eccentricity, inclination, mean_motion, epoch]
+            default: number
+        - name: sort_order
+          in: query
+          description: Sort order
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: asc
+        - name: designation
+          in: query
+          description: Filter by designation (partial match)
+          required: false
+          schema:
+            type: string
+        - name: number
+          in: query
+          description: Filter by exact MPC number
+          required: false
+          schema:
+            type: integer
+        - name: numbered
+          in: query
+          description: "true: only numbered asteroids; false: only unnumbered/provisional"
+          required: false
+          schema:
+            type: boolean
+        - name: mag_min
+          in: query
+          description: Minimum absolute magnitude (H)
+          required: false
+          schema:
+            type: number
+            format: float
+        - name: mag_max
+          in: query
+          description: Maximum absolute magnitude (H)
+          required: false
+          schema:
+            type: number
+            format: float
+      responses:
+        '200':
+          description: List of asteroids with pagination info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsteroidsList'
+        '422':
+          description: Invalid parameters (e.g. mag_min greater than mag_max)
+      security:
+        - bearerAuth: []
+    post:
+      summary: Get list of asteroids
+      description: Returns a paginated list of asteroids (minor planets) with sorting and filtering options
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                page:
+                  type: integer
+                  description: Page number (starting from 1)
+                  default: 1
+                  minimum: 1
+                per_page:
+                  type: integer
+                  description: Number of items per page
+                  default: 100
+                  minimum: 1
+                  maximum: 1000
+                sort_by:
+                  type: string
+                  description: Field to sort by
+                  enum: [number, designation, absolute_magnitude, semimajor_axis, eccentricity, inclination, mean_motion, epoch]
+                  default: number
+                sort_order:
+                  type: string
+                  description: Sort order
+                  enum: [asc, desc]
+                  default: asc
+                designation:
+                  type: string
+                  description: Filter by designation (partial match)
+                number:
+                  type: integer
+                  description: Filter by exact MPC number
+                numbered:
+                  type: boolean
+                  description: "true: only numbered asteroids; false: only unnumbered/provisional"
+                mag_min:
+                  type: number
+                  format: float
+                  description: Minimum absolute magnitude (H)
+                mag_max:
+                  type: number
+                  format: float
+                  description: Maximum absolute magnitude (H)
+      responses:
+        '200':
+          description: List of asteroids with pagination info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsteroidsList'
+        '422':
+          description: Invalid parameters (e.g. mag_min greater than mag_max)
+      security:
+        - bearerAuth: []
+  /api/asteroids/{asteroid_id}:
+    get:
+      summary: Get asteroid details
+      description: Returns a single asteroid's full orbital element set by its internal ID
+      parameters:
+        - name: asteroid_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Asteroid details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsteroidResponse'
+        '404':
+          description: Asteroid not found
       security:
         - bearerAuth: []

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1141,6 +1141,63 @@ components:
           $ref: '#/components/schemas/Asteroid'
         msg:
           type: string
+    AsteroidVisibilitySample:
+      type: object
+      properties:
+        time:
+          type: string
+          description: Sample time (UTC)
+        altitude_deg:
+          type: number
+          format: float
+          description: Altitude above the horizon (degrees)
+        azimuth_deg:
+          type: number
+          format: float
+          description: Azimuth (degrees, from North through East)
+        apparent_magnitude:
+          type: number
+          format: float
+          nullable: true
+          description: Estimated apparent magnitude, if H is known
+    AsteroidVisibilityResponse:
+      type: object
+      properties:
+        status:
+          type: boolean
+        scope_id:
+          type: integer
+        scope_name:
+          type: string
+        night_start:
+          type: string
+          description: Start of the astronomical night (UTC)
+        night_end:
+          type: string
+          description: End of the astronomical night (UTC)
+        samples:
+          type: array
+          items:
+            $ref: '#/components/schemas/AsteroidVisibilitySample'
+        max_altitude_deg:
+          type: number
+          format: float
+          description: Highest altitude reached during the night
+        max_altitude_time:
+          type: string
+          description: Time of highest altitude (UTC)
+        apparent_magnitude_at_max:
+          type: number
+          format: float
+          nullable: true
+        visible:
+          type: boolean
+          description: Whether the asteroid rises above the horizon during the night
+        has_magnitude_estimate:
+          type: boolean
+          description: Whether absolute_magnitude (H) was available
+        msg:
+          type: string
     Catalog:
       type: object
       properties:
@@ -3339,6 +3396,54 @@ paths:
                 $ref: '#/components/schemas/AsteroidResponse'
         '404':
           description: Asteroid not found
+      security:
+        - bearerAuth: []
+  /api/asteroids/{asteroid_id}/visibility:
+    get:
+      summary: Compute asteroid visibility for a night from a telescope's location
+      description: >-
+        Computes altitude, azimuth, and (if absolute magnitude H is known) estimated apparent
+        magnitude across a night for one asteroid as seen from a telescope's location.
+        Defaults to tonight; pass `date` to check a different night.
+      parameters:
+        - name: asteroid_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: scope_id
+          in: query
+          description: Telescope to compute visibility from
+          required: true
+          schema:
+            type: integer
+        - name: date
+          in: query
+          description: Evening date (YYYY-MM-DD) whose night to compute; defaults to tonight
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: step_minutes
+          in: query
+          description: Sampling interval across the night, in minutes
+          required: false
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 120
+      responses:
+        '200':
+          description: Visibility curve for the requested night
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsteroidVisibilityResponse'
+        '400':
+          description: Telescope has no location configured
+        '404':
+          description: Asteroid or telescope not found
       security:
         - bearerAuth: []
   /api/asteroid-tags:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -991,6 +991,10 @@ components:
         designation:
           type: string
           description: Packed MPC designation
+        name:
+          type: string
+          nullable: true
+          description: Proper name (null if unnamed)
         epoch:
           type: string
           description: Epoch in MPC packed format
@@ -3248,7 +3252,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [number, designation, absolute_magnitude, semimajor_axis, eccentricity, inclination, mean_motion, epoch]
+            enum: [number, designation, name, absolute_magnitude, semimajor_axis, eccentricity, inclination, mean_motion, epoch]
             default: number
         - name: sort_order
           in: query
@@ -3261,6 +3265,12 @@ paths:
         - name: designation
           in: query
           description: Filter by designation (partial match)
+          required: false
+          schema:
+            type: string
+        - name: name
+          in: query
+          description: Filter by proper name (partial match, case-insensitive)
           required: false
           schema:
             type: string
@@ -3339,7 +3349,7 @@ paths:
                 sort_by:
                   type: string
                   description: Field to sort by
-                  enum: [number, designation, absolute_magnitude, semimajor_axis, eccentricity, inclination, mean_motion, epoch]
+                  enum: [number, designation, name, absolute_magnitude, semimajor_axis, eccentricity, inclination, mean_motion, epoch]
                   default: number
                 sort_order:
                   type: string
@@ -3349,6 +3359,9 @@ paths:
                 designation:
                   type: string
                   description: Filter by designation (partial match)
+                name:
+                  type: string
+                  description: Filter by proper name (partial match, case-insensitive)
                 number:
                   type: integer
                   description: Filter by exact MPC number

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -424,6 +424,22 @@ def run():
         '--no-color', action='store_true',
         help="Disable ANSI colors in the output",
     )
+    show_parser.add_argument(
+        '--telescope-id', type=int, default=None, dest='telescope_id',
+        help="Telescope scope_id for a night visibility chart",
+    )
+    show_parser.add_argument(
+        '--telescope', type=str, default=None,
+        help="Telescope name for a night visibility chart (exact or unique partial match)",
+    )
+    show_parser.add_argument(
+        '--date', type=str, default=None,
+        help="Evening date YYYY-MM-DD for the visibility chart (default: today)",
+    )
+    show_parser.add_argument(
+        '--step-minutes', type=int, default=10, dest='step_minutes',
+        help="Visibility sampling interval in minutes (default: 10)",
+    )
     vis_parser = asteroid_subparsers.add_parser('visible', help="List asteroids visible during a night (magnitude and altitude filters)")
     vis_parser.add_argument("--date", help="Observation date YYYY-MM-DD", type=str, required=True)
     vis_parser.add_argument("--lat", help="Observer latitude (degrees)", type=float, required=True)

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -45,7 +45,12 @@ from hevelius.cmd_equipment import (
     add_telescope_filter,
     remove_telescope_filter,
 )
-from hevelius.cmd_asteroid import asteroids_download, asteroids_visible
+from hevelius.cmd_asteroid import (
+    asteroids_download,
+    asteroids_load,
+    asteroids_status,
+    asteroids_visible,
+)
 
 
 def run():
@@ -365,10 +370,43 @@ def run():
 
     asteroid_parser = subparsers.add_parser('asteroid', help="Asteroid observation planning (MPC orbits, visibility)")
     asteroid_subparsers = asteroid_parser.add_subparsers(help="asteroid commands", dest="asteroid_command")
-    dl_parser = asteroid_subparsers.add_parser('download', help="Download MPCORB.DAT from Minor Planet Center and cache locally")
-    dl_parser.add_argument("-f", "--force", help="Re-download even if cache exists", action='store_true')
-    dl_parser.add_argument("--load", help="Load (or update) asteroids into the database after download", action='store_true')
-    dl_parser.add_argument("--limit", help="Max number of orbits to load (default: all)", type=int, default=None)
+    dl_parser = asteroid_subparsers.add_parser(
+        'download',
+        help="Download MPCORB.DAT from Minor Planet Center and cache locally "
+             "(skipped if cache is younger than 7 days unless --force)",
+    )
+    dl_parser.add_argument(
+        "-f", "--force",
+        help="Re-download even if a fresh cache (younger than 7 days) exists",
+        action='store_true',
+    )
+    dl_parser.add_argument(
+        "--load",
+        help="Load (or update) asteroids into the database after download "
+             "(same as running 'asteroid load')",
+        action='store_true',
+    )
+    dl_parser.add_argument("--limit", help="Max number of orbits to load with --load (default: all)", type=int, default=None)
+    load_parser = asteroid_subparsers.add_parser(
+        'load',
+        help="Create or update asteroid orbital data in the DB from the cached MPCORB file",
+    )
+    load_parser.add_argument(
+        "--file",
+        help="Path to MPCORB.DAT (default: local cache from 'asteroid download')",
+        type=str,
+        default=None,
+    )
+    load_parser.add_argument("--limit", help="Max number of orbits to load (default: all)", type=int, default=None)
+    status_parser = asteroid_subparsers.add_parser(
+        'status',
+        help="Show MPCORB download/cache status and asteroid database counters",
+    )
+    status_parser.add_argument(
+        "--count-file",
+        help="Also count asteroid records in the cached MPCORB file (slower)",
+        action='store_true',
+    )
     vis_parser = asteroid_subparsers.add_parser('visible', help="List asteroids visible during a night (magnitude and altitude filters)")
     vis_parser.add_argument("--date", help="Observation date YYYY-MM-DD", type=str, required=True)
     vis_parser.add_argument("--lat", help="Observer latitude (degrees)", type=float, required=True)
@@ -686,8 +724,11 @@ def run():
         return user_parser.print_help() or 1
     if args.command == "asteroid":
         if args.asteroid_command == "download":
-            asteroids_download(args)
-            return 0
+            return asteroids_download(args)
+        if args.asteroid_command == "load":
+            return asteroids_load(args)
+        if args.asteroid_command == "status":
+            return asteroids_status(args)
         if args.asteroid_command == "visible":
             return asteroids_visible(args)
         return asteroid_parser.print_help()

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -48,6 +48,7 @@ from hevelius.cmd_equipment import (
 from hevelius.cmd_asteroid import (
     asteroids_download,
     asteroids_load,
+    asteroids_show,
     asteroids_status,
     asteroids_visible,
 )
@@ -407,6 +408,22 @@ def run():
         help="Also count asteroid records in the cached MPCORB file (slower)",
         action='store_true',
     )
+    show_parser = asteroid_subparsers.add_parser(
+        'show',
+        help="Show detailed info for an asteroid by name, MPC number, or packed designation",
+    )
+    show_parser.add_argument(
+        'query',
+        help="Proper name (e.g. Ceres), MPC number (e.g. 1), or packed designation",
+    )
+    show_parser.add_argument(
+        '--limit', type=int, default=20,
+        help="Max matches to list when the query is ambiguous (default: 20)",
+    )
+    show_parser.add_argument(
+        '--no-color', action='store_true',
+        help="Disable ANSI colors in the output",
+    )
     vis_parser = asteroid_subparsers.add_parser('visible', help="List asteroids visible during a night (magnitude and altitude filters)")
     vis_parser.add_argument("--date", help="Observation date YYYY-MM-DD", type=str, required=True)
     vis_parser.add_argument("--lat", help="Observer latitude (degrees)", type=float, required=True)
@@ -729,6 +746,8 @@ def run():
             return asteroids_load(args)
         if args.asteroid_command == "status":
             return asteroids_status(args)
+        if args.asteroid_command == "show":
+            return asteroids_show(args)
         if args.asteroid_command == "visible":
             return asteroids_visible(args)
         return asteroid_parser.print_help()

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -47,6 +47,7 @@ from hevelius.cmd_equipment import (
 )
 from hevelius.cmd_asteroid import (
     asteroids_download,
+    asteroids_list,
     asteroids_load,
     asteroids_show,
     asteroids_status,
@@ -440,6 +441,54 @@ def run():
         '--step-minutes', type=int, default=10, dest='step_minutes',
         help="Visibility sampling interval in minutes (default: 10)",
     )
+
+    list_parser = asteroid_subparsers.add_parser(
+        'list',
+        help="List asteroids from the catalogue (default: first 100 by MPC number)",
+    )
+    list_parser.add_argument(
+        '--limit', type=int, default=100,
+        help="Max rows to print (default: 100)",
+    )
+    list_parser.add_argument(
+        '--offset', type=int, default=0,
+        help="Skip this many rows before printing (default: 0)",
+    )
+    list_parser.add_argument(
+        '--sort-by', dest='sort_by', default='number',
+        choices=[
+            'number', 'name', 'designation', 'absolute_magnitude',
+            'semimajor_axis', 'eccentricity', 'inclination', 'mean_motion', 'epoch',
+        ],
+        help="Sort field (default: number)",
+    )
+    list_parser.add_argument(
+        '--sort-order', dest='sort_order', default='asc', choices=['asc', 'desc'],
+        help="Sort direction (default: asc)",
+    )
+    list_parser.add_argument('--name', type=str, default=None,
+                             help="Filter by proper name (partial, case-insensitive)")
+    list_parser.add_argument('--designation', type=str, default=None,
+                             help="Filter by packed designation (partial, case-insensitive)")
+    list_parser.add_argument('--number', type=int, default=None,
+                             help="Filter by exact MPC number")
+    list_parser.add_argument('--numbered', action='store_true', default=None,
+                             help="Only numbered asteroids")
+    list_parser.add_argument('--unnumbered', action='store_true',
+                             help="Only unnumbered / provisional asteroids")
+    list_parser.add_argument('--mag-min', type=float, default=None, dest='mag_min',
+                             help="Minimum absolute magnitude H")
+    list_parser.add_argument('--mag-max', type=float, default=None, dest='mag_max',
+                             help="Maximum absolute magnitude H")
+    list_parser.add_argument('--tags', type=str, default=None,
+                             help="Comma-separated tag names to filter by (e.g. neo,pha)")
+    list_parser.add_argument(
+        '--tags-mode', dest='tags_mode', default='any', choices=['any', 'all'],
+        help="'any' (default) = at least one tag; 'all' = every listed tag",
+    )
+    list_parser.add_argument('--no-color', action='store_true',
+                             help="Disable ANSI colors in the output")
+
     vis_parser = asteroid_subparsers.add_parser('visible', help="List asteroids visible during a night (magnitude and altitude filters)")
     vis_parser.add_argument("--date", help="Observation date YYYY-MM-DD", type=str, required=True)
     vis_parser.add_argument("--lat", help="Observer latitude (degrees)", type=float, required=True)
@@ -764,6 +813,8 @@ def run():
             return asteroids_status(args)
         if args.asteroid_command == "show":
             return asteroids_show(args)
+        if args.asteroid_command == "list":
+            return asteroids_list(args)
         if args.asteroid_command == "visible":
             return asteroids_visible(args)
         return asteroid_parser.print_help()

--- a/db/23-asteroid-tags.psql
+++ b/db/23-asteroid-tags.psql
@@ -1,0 +1,23 @@
+-- Tags for asteroids (e.g. amor, neo, pha, fast rotator, visited by spacecraft).
+-- Many-to-many: an asteroid can carry multiple tags, a tag applies to many asteroids.
+
+CREATE TABLE IF NOT EXISTS asteroid_tags (
+    tag_id SERIAL PRIMARY KEY,
+    name VARCHAR(64) NOT NULL,
+    description VARCHAR(256),
+    color VARCHAR(16),
+    UNIQUE (name)
+);
+
+CREATE TABLE IF NOT EXISTS asteroid_tag_map (
+    asteroid_id INTEGER NOT NULL REFERENCES asteroids(id) ON DELETE CASCADE,
+    tag_id INTEGER NOT NULL REFERENCES asteroid_tags(tag_id) ON DELETE CASCADE,
+    PRIMARY KEY (asteroid_id, tag_id)
+);
+
+-- The composite PK (asteroid_id, tag_id) already serves "tags for asteroid X"
+-- lookups. This extra index on tag_id serves the reverse direction: "asteroids
+-- with tag Y" and multi-tag filtering (both ANY and ALL semantics).
+CREATE INDEX asteroid_tag_map_tag_id_idx ON asteroid_tag_map (tag_id);
+
+UPDATE schema_version SET version = 23;

--- a/db/24-asteroid-tags.psql
+++ b/db/24-asteroid-tags.psql
@@ -20,4 +20,4 @@ CREATE TABLE IF NOT EXISTS asteroid_tag_map (
 -- with tag Y" and multi-tag filtering (both ANY and ALL semantics).
 CREATE INDEX asteroid_tag_map_tag_id_idx ON asteroid_tag_map (tag_id);
 
-UPDATE schema_version SET version = 23;
+UPDATE schema_version SET version = 24;

--- a/db/24-asteroid-tags.psql
+++ b/db/24-asteroid-tags.psql
@@ -1,5 +1,12 @@
 -- Tags for asteroids (e.g. amor, neo, pha, fast rotator, visited by spacecraft).
 -- Many-to-many: an asteroid can carry multiple tags, a tag applies to many asteroids.
+-- Also adds the optional proper name column (from MPCORB readable designation).
+
+ALTER TABLE asteroids ADD COLUMN IF NOT EXISTS name VARCHAR(64);
+-- Case-insensitive exact lookups for CLI/API name search; partial ILIKE still
+-- needs a sequential scan (or pg_trgm later) at full catalogue scale.
+CREATE INDEX IF NOT EXISTS asteroids_name_lower_idx
+    ON asteroids (lower(name)) WHERE name IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS asteroid_tags (
     tag_id SERIAL PRIMARY KEY,

--- a/db/wipe.psql
+++ b/db/wipe.psql
@@ -8,4 +8,7 @@ DROP TABLE IF EXISTS filters CASCADE;
 DROP TABLE IF EXISTS mymfavorites;
 DROP TABLE IF EXISTS task_states;
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS asteroid_tag_map;
+DROP TABLE IF EXISTS asteroid_tags;
+DROP TABLE IF EXISTS asteroids;
 DROP TABLE IF EXISTS schema_version;

--- a/doc/asteroids.md
+++ b/doc/asteroids.md
@@ -69,6 +69,8 @@ hevelius asteroid download [--force] [--load] [--limit N]
 hevelius asteroid load [--file PATH] [--limit N]
 hevelius asteroid show Ceres
 hevelius asteroid show 433
+hevelius asteroid show Vesta --telescope-id 3
+hevelius asteroid show Vesta --telescope hakos-e180 --date 2026-07-22
 hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
     --mag-min 8 --mag-max 14 --alt-min 20
 ```
@@ -82,6 +84,10 @@ hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
 | `download --load` | off | After download, upsert into the DB |
 | `load` | — | Upsert asteroids from the cached (or `--file`) MPCORB |
 | `show <query>` | — | Detail by proper name, MPC number, or packed designation |
+| `show --telescope` | — | Telescope name → night altitude chart from that site |
+| `show --telescope-id` | — | Telescope scope_id → night altitude chart |
+| `show --date` | today | Evening date for the visibility chart |
+| `show --step-minutes` | 10 | Chart sampling interval |
 | `show --limit` | 20 | Max candidates listed when the query is ambiguous |
 | `show --no-color` | off | Disable ANSI colors |
 | `visible --date` | required | Observation date (YYYY-MM-DD) |
@@ -96,7 +102,11 @@ hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
 
 `asteroid show` prefers exact name/number/designation matches. Ambiguous queries
 list candidates. When stdout is a TTY, the detail view uses ANSI colors
-(disable with `--no-color`).
+(disable with `--no-color`). Pass `--telescope` or `--telescope-id` to compute
+a night altitude curve from that telescope's GPS coordinates and draw it as a
+console chart (`--date` defaults to today). The chart spans sunset→sunrise,
+lists sunset/sunrise and moonrise/moonset, and paints markers yellow while the
+Moon is above the horizon.
 
 Progress for `visible` is printed to stderr so stdout output can be redirected
 to a file.

--- a/doc/asteroids.md
+++ b/doc/asteroids.md
@@ -71,6 +71,9 @@ hevelius asteroid show Ceres
 hevelius asteroid show 433
 hevelius asteroid show Vesta --telescope-id 3
 hevelius asteroid show Vesta --telescope hakos-e180 --date 2026-07-22
+hevelius asteroid list
+hevelius asteroid list --name cer --limit 20
+hevelius asteroid list --numbered --sort-by absolute_magnitude --sort-order asc
 hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
     --mag-min 8 --mag-max 14 --alt-min 20
 ```
@@ -90,6 +93,17 @@ hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
 | `show --step-minutes` | 10 | Chart sampling interval |
 | `show --limit` | 20 | Max candidates listed when the query is ambiguous |
 | `show --no-color` | off | Disable ANSI colors |
+| `list` | — | Catalogue listing (default first 100 by MPC number) |
+| `list --limit` | 100 | Max rows to print |
+| `list --offset` | 0 | Skip N rows before printing |
+| `list --sort-by` | number | number, name, designation, absolute_magnitude, … |
+| `list --sort-order` | asc | asc or desc |
+| `list --name` | — | Proper-name filter (partial) |
+| `list --designation` | — | Packed-designation filter (partial) |
+| `list --number` | — | Exact MPC number |
+| `list --numbered` / `--unnumbered` | — | Numbered-only / provisional-only |
+| `list --mag-min` / `--mag-max` | — | Absolute magnitude H range |
+| `list --tags` / `--tags-mode` | any | Tag filter (`any` or `all`) |
 | `visible --date` | required | Observation date (YYYY-MM-DD) |
 | `visible --lat` | required | Observer latitude in degrees |
 | `visible --lon` | required | Observer longitude in degrees |

--- a/doc/asteroids.md
+++ b/doc/asteroids.md
@@ -9,15 +9,19 @@ data source, the database schema, the CLI, and the visibility algorithm in detai
 
 Orbital elements come from the [MPC MPCORB database](https://minorplanetcenter.net/iau/MPCORB.html).
 The full catalogue is distributed as a gzip-compressed fixed-width text file
-(`MPCORB.DAT.gz`).  Download and load it with:
+(`MPCORB.DAT.gz`).  Typical workflow:
 
 ```
-hevelius asteroid download --load
+hevelius asteroid status                 # cache + DB counters
+hevelius asteroid download               # fetch MPCORB (skipped if < 7 days old)
+hevelius asteroid load                   # upsert into the asteroids table
+# or: hevelius asteroid download --load  # download then load
 ```
 
-The file is cached locally (default: `~/.cache/hevelius/MPCORB.DAT`).  To
-force a re-download use `--force`.  The `--limit N` flag restricts the load to
-the first *N* records, which is handy for testing.
+The file is cached locally (default: `~/.cache/hevelius/MPCORB.DAT`).  A
+download is skipped when that cache is younger than 7 days; use `--force` to
+re-download anyway.  The `--limit N` flag on `load` (or `download --load`)
+restricts the load to the first *N* records, which is handy for testing.
 
 ## Database schema
 
@@ -43,23 +47,33 @@ Indices exist on `absolute_magnitude`, `number`, and `designation`.
 ## CLI usage
 
 ```
+hevelius asteroid status
+hevelius asteroid download [--force] [--load] [--limit N]
+hevelius asteroid load [--file PATH] [--limit N]
 hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
     --mag-min 8 --mag-max 14 --alt-min 20
 ```
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--date` | required | Observation date (YYYY-MM-DD) |
-| `--lat` | required | Observer latitude in degrees |
-| `--lon` | required | Observer longitude in degrees |
-| `--alt` | 0 | Observer altitude above sea level (metres) |
-| `--mag-min` | 8.0 | Minimum apparent magnitude |
-| `--mag-max` | 16.0 | Maximum apparent magnitude |
-| `--alt-min` | 20.0 | Minimum altitude above horizon (degrees) |
-| `--constraint` | — | Extra SQL filter, e.g. `'number < 3000'` |
-| `--order-by` | absolute\_magnitude | Sort column |
+| Command / option | Default | Description |
+|------------------|---------|-------------|
+| `status` | — | MPCORB cache location/age and DB asteroid counters |
+| `status --count-file` | off | Also count records in the cached MPCORB file |
+| `download` | — | Fetch MPCORB; skipped if cache younger than 7 days |
+| `download --force` | off | Re-download even if the cache is fresh |
+| `download --load` | off | After download, upsert into the DB |
+| `load` | — | Upsert asteroids from the cached (or `--file`) MPCORB |
+| `visible --date` | required | Observation date (YYYY-MM-DD) |
+| `visible --lat` | required | Observer latitude in degrees |
+| `visible --lon` | required | Observer longitude in degrees |
+| `visible --alt` | 0 | Observer altitude above sea level (metres) |
+| `visible --mag-min` | 8.0 | Minimum apparent magnitude |
+| `visible --mag-max` | 16.0 | Maximum apparent magnitude |
+| `visible --alt-min` | 20.0 | Minimum altitude above horizon (degrees) |
+| `visible --constraint` | — | Extra SQL filter, e.g. `'number < 3000'` |
+| `visible --order-by` | absolute\_magnitude | Sort column |
 
-Progress is printed to stderr so stdout output can be redirected to a file.
+Progress for `visible` is printed to stderr so stdout output can be redirected
+to a file.
 
 ## Visibility algorithm
 

--- a/doc/asteroids.md
+++ b/doc/asteroids.md
@@ -28,14 +28,19 @@ Permanent MPC numbers are unpacked from the packed designation in columns 1–7
 (plain digits, letter-coded forms for 100000–619999, and tilde/base-62 for
 ≥ 620000). Provisional designations leave `number` NULL.
 
+Proper names come from the MPCORB readable designation field (columns 167–194),
+e.g. `(1) Ceres` → `name = Ceres`. Unnamed and provisional objects store NULL.
+
 ## Database schema
 
-Orbital elements are stored in the `asteroids` table (migration **22**):
+Orbital elements are stored in the `asteroids` table (migration **22**, with
+`name` added in migration **24**):
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `number` | integer | MPC number (NULL for unnumbered objects) |
 | `designation` | varchar(32) | Packed MPC designation (unique key) |
+| `name` | varchar(64) | Proper name (NULL if unnamed / provisional) |
 | `epoch` | varchar(16) | Epoch in MPC packed format |
 | `mean_anomaly` | double | Mean anomaly M at epoch (degrees) |
 | `perihelion_arg` | double | Argument of perihelion ω (degrees) |
@@ -47,7 +52,7 @@ Orbital elements are stored in the `asteroids` table (migration **22**):
 | `absolute_magnitude` | double | Absolute magnitude H |
 | `slope_parameter` | double | Phase slope parameter G (default 0.15) |
 
-Indices exist on `absolute_magnitude`, `number`, and `designation`.
+Indices exist on `absolute_magnitude`, `number`, `designation`, and `lower(name)`.
 
 ### Tags (migration 24)
 
@@ -62,6 +67,8 @@ same pattern as other shared catalogue metadata.
 hevelius asteroid status
 hevelius asteroid download [--force] [--load] [--limit N]
 hevelius asteroid load [--file PATH] [--limit N]
+hevelius asteroid show Ceres
+hevelius asteroid show 433
 hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
     --mag-min 8 --mag-max 14 --alt-min 20
 ```
@@ -74,6 +81,9 @@ hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
 | `download --force` | off | Re-download even if the cache is fresh |
 | `download --load` | off | After download, upsert into the DB |
 | `load` | — | Upsert asteroids from the cached (or `--file`) MPCORB |
+| `show <query>` | — | Detail by proper name, MPC number, or packed designation |
+| `show --limit` | 20 | Max candidates listed when the query is ambiguous |
+| `show --no-color` | off | Disable ANSI colors |
 | `visible --date` | required | Observation date (YYYY-MM-DD) |
 | `visible --lat` | required | Observer latitude in degrees |
 | `visible --lon` | required | Observer longitude in degrees |
@@ -84,6 +94,10 @@ hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
 | `visible --constraint` | — | Extra SQL filter, e.g. `'number < 3000'` |
 | `visible --order-by` | absolute\_magnitude | Sort column |
 
+`asteroid show` prefers exact name/number/designation matches. Ambiguous queries
+list candidates. When stdout is a TTY, the detail view uses ANSI colors
+(disable with `--no-color`).
+
 Progress for `visible` is printed to stderr so stdout output can be redirected
 to a file.
 
@@ -93,7 +107,7 @@ See `api/openapi.yaml` for the full contract. Summary:
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET/POST | `/api/asteroids` | Paginated list with filters (designation, number, magnitude, tags) |
+| GET/POST | `/api/asteroids` | Paginated list with filters (name, designation, number, magnitude, tags) |
 | GET | `/api/asteroids/{id}` | Detail including attached tags |
 | GET | `/api/asteroids/{id}/visibility` | Night altitude/azimuth/magnitude curve from a telescope |
 | GET/POST | `/api/asteroid-tags` | List / create tags |

--- a/doc/asteroids.md
+++ b/doc/asteroids.md
@@ -3,7 +3,8 @@
 Hevelius can identify asteroids that are observable from your site on a given
 night.  With over one million asteroids in the Minor Planet Center (MPC)
 catalogue, the implementation needs to be fast.  This document describes the
-data source, the database schema, the CLI, and the visibility algorithm in detail.
+data source, the database schema, the CLI, the REST API, and the visibility
+algorithm in detail.
 
 ## Data source
 
@@ -23,9 +24,13 @@ download is skipped when that cache is younger than 7 days; use `--force` to
 re-download anyway.  The `--limit N` flag on `load` (or `download --load`)
 restricts the load to the first *N* records, which is handy for testing.
 
+Permanent MPC numbers are unpacked from the packed designation in columns 1–7
+(plain digits, letter-coded forms for 100000–619999, and tilde/base-62 for
+≥ 620000). Provisional designations leave `number` NULL.
+
 ## Database schema
 
-Orbital elements are stored in the `asteroids` table (migration 15):
+Orbital elements are stored in the `asteroids` table (migration **22**):
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -43,6 +48,13 @@ Orbital elements are stored in the `asteroids` table (migration 15):
 | `slope_parameter` | double | Phase slope parameter G (default 0.15) |
 
 Indices exist on `absolute_magnitude`, `number`, and `designation`.
+
+### Tags (migration 24)
+
+Shared tag vocabulary lives in `asteroid_tags` (`name`, optional `description` /
+`color`) with a many-to-many map `asteroid_tag_map`. Any authenticated API user
+may create, edit, delete, or attach tags — the vocabulary is deployment-wide,
+same pattern as other shared catalogue metadata.
 
 ## CLI usage
 
@@ -74,6 +86,32 @@ hevelius asteroid visible --date 2026-06-15 --lat 52.2 --lon 21.0 \
 
 Progress for `visible` is printed to stderr so stdout output can be redirected
 to a file.
+
+## REST API
+
+See `api/openapi.yaml` for the full contract. Summary:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET/POST | `/api/asteroids` | Paginated list with filters (designation, number, magnitude, tags) |
+| GET | `/api/asteroids/{id}` | Detail including attached tags |
+| GET | `/api/asteroids/{id}/visibility` | Night altitude/azimuth/magnitude curve from a telescope |
+| GET/POST | `/api/asteroid-tags` | List / create tags |
+| GET/PATCH/DELETE | `/api/asteroid-tags/{id}` | Tag CRUD |
+| POST/DELETE | `/api/asteroids/{id}/tags[/{tag_id}]` | Attach / detach |
+
+All endpoints require JWT (`bearerAuth`).
+
+### Visibility curve semantics
+
+- Default `date` is the **server's local calendar date**, not the telescope site's timezone.
+- `visible` is true when max altitude during the night is **above 0°** (geometric horizon only; no airmass or site horizon mask).
+- `step_minutes` (1–120, default 10) controls sampling density; smaller steps are more CPU-heavy.
+
+### List performance note
+
+Unfiltered list responses always run `COUNT(*)` on `asteroids`. At full MPCORB
+scale that can be expensive; prefer filters when browsing large catalogues.
 
 ## Visibility algorithm
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -95,6 +95,10 @@ hevelius asteroid download --load
 # Look up one asteroid by proper name, MPC number, or packed designation
 hevelius asteroid show Ceres
 hevelius asteroid show 433
+
+# With a telescope, also print a night altitude chart for that site
+hevelius asteroid show Vesta --telescope-id 3
+hevelius asteroid show Vesta --telescope hakos-e180 --date 2026-07-22
 ```
 
 The orbital parameters are cached locally (default: `~/.cache/hevelius/MPCORB.DAT`).

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -91,6 +91,10 @@ hevelius asteroid load
 
 # Or download and load in one step
 hevelius asteroid download --load
+
+# Look up one asteroid by proper name, MPC number, or packed designation
+hevelius asteroid show Ceres
+hevelius asteroid show 433
 ```
 
 The orbital parameters are cached locally (default: `~/.cache/hevelius/MPCORB.DAT`).

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -73,28 +73,37 @@ python bin/hevelius catalog --object C38 --proximity 0.5 --format full
 
 ## Asteroids
 
-A basic support for asteroid handling is available.
-
-First, you need to download and load asteroid data from MPC.
+Asteroid orbital elements come from the Minor Planet Center (MPCORB). Typical
+workflow:
 
 ```shell
+# Check whether MPCORB was downloaded and whether the DB has asteroids
+hevelius asteroid status
+
+# Download MPCORB.DAT (skipped if the local cache is younger than 7 days)
 hevelius asteroid download
+
+# Force a re-download regardless of cache age
+hevelius asteroid download --force
+
+# Upsert orbital elements from the cached file into the database
+hevelius asteroid load
+
+# Or download and load in one step
+hevelius asteroid download --load
 ```
 
-The orbitalal parameters downloaded are cached. You can force redownloading
-by using `--force`. Please be gentle on the MPC servers. The data can be loaded
-into database if `--load` is specified. The data can optionally be limited
-using `--limit LIMIT`, e.g. to load first 10 entries just for testing.
+The orbital parameters are cached locally (default: `~/.cache/hevelius/MPCORB.DAT`).
+Please be gentle on the MPC servers. Use `--limit N` with `load` (or
+`download --load`) to load only the first *N* records for testing.
 
-Once the database is loaded, the next step is to show visible asteroids.
-Several parameters are mandatory: `--date` that specifies the night date,
-and observatory location, using `--lat` and `--lon`. Many for parameters
-might be specified to filter list of asteroids. For complete list, see
-`bin/hevelius asteroid visible --help`.
+Once the database is loaded, list visible asteroids. Mandatory parameters are
+`--date` (night date) and observatory location (`--lat`, `--lon`). See
+`bin/hevelius asteroid visible --help` for the full filter list.
 
 An example usage:
 
 ```shell
 # Visible asteroids on a given night (e.g. mag 10–14, altitude ≥ 25°, numbered < 3000)
-hevelius asteroids visible --date 2025-03-15 --lat 52.2 --lon 21.0 --mag-min 10 --mag-max 14 --alt-min 25 --constraint number_lt_3000 --order-by number
+hevelius asteroid visible --date 2025-03-15 --lat 52.2 --lon 21.0 --mag-min 10 --mag-max 14 --alt-min 25 --constraint number_lt_3000 --order-by number
 ```

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -96,6 +96,10 @@ hevelius asteroid download --load
 hevelius asteroid show Ceres
 hevelius asteroid show 433
 
+# Catalogue listing (first 100 by MPC number; filters/sorting available)
+hevelius asteroid list
+hevelius asteroid list --name cer --limit 20 --sort-by absolute_magnitude
+
 # With a telescope, also print a night altitude chart for that site
 hevelius asteroid show Vesta --telescope-id 3
 hevelius asteroid show Vesta --telescope hakos-e180 --date 2026-07-22

--- a/doc/db.md
+++ b/doc/db.md
@@ -20,6 +20,13 @@ python bin/hevelius migrate
 
 he_solved_ra - Right Ascension, from the plate solving, in degrees (0-359)
 
+### Schema version 24 (asteroid tags)
+
+- **asteroid_tags** – Shared tag vocabulary for asteroids (`name` unique, optional
+  `description` / `color`). Examples: neo, pha, amor, fast rotator.
+- **asteroid_tag_map** – Many-to-many link (`asteroid_id`, `tag_id`) with cascade
+  deletes; index on `tag_id` for reverse lookups and multi-tag list filters.
+
 ### Schema version 23 (project rotation, optical params, telescope default rotation)
 
 - **projects** – Added **rotation** (float, degrees East of North, nullable; user-supplied or defaulted
@@ -32,7 +39,8 @@ he_solved_ra - Right Ascension, from the plate solving, in degrees (0-359)
 ### Schema version 22 (asteroids)
 
 - **asteroids** – MPC orbital elements for visibility planning (`designation`, epoch, Keplerian
-  elements, absolute magnitude / slope). Used by asteroid night-visibility queries.
+  elements, absolute magnitude / slope). Used by asteroid night-visibility queries and the
+  REST asteroid list/detail/visibility API.
 
 ### Schema version 18 (users cleanup, audit, password reset)
 

--- a/doc/db.md
+++ b/doc/db.md
@@ -20,8 +20,11 @@ python bin/hevelius migrate
 
 he_solved_ra - Right Ascension, from the plate solving, in degrees (0-359)
 
-### Schema version 24 (asteroid tags)
+### Schema version 24 (asteroid tags + proper names)
 
+- **asteroids** – Added optional **name** (varchar 64): proper name parsed from the
+  MPCORB readable designation field (e.g. `Ceres` from `(1) Ceres`). NULL for
+  unnamed / provisional objects. Index on `lower(name)` for exact lookups.
 - **asteroid_tags** – Shared tag vocabulary for asteroids (`name` unique, optional
   `description` / `color`). Examples: neo, pha, amor, fast rotator.
 - **asteroid_tag_map** – Many-to-many link (`asteroid_id`, `tag_id`) with cascade

--- a/hevelius/cmd_asteroid.py
+++ b/hevelius/cmd_asteroid.py
@@ -3,10 +3,12 @@ Asteroid observation planning: download MPC orbits, list visible asteroids
 for a given night/location with magnitude and altitude filters.
 """
 
+import datetime
 import gzip
 import os
 import re
 import sys
+import urllib.error
 import urllib.request
 from typing import List, Optional, Tuple
 
@@ -54,6 +56,9 @@ MPCORB_COLS = {
 
 MPCORB_URL = "https://minorplanetcenter.net/iau/MPCORB/MPCORB.DAT.gz"
 
+# Skip re-download from MPC when the local cache is younger than this.
+MPCORB_MAX_AGE_DAYS = 7
+
 
 def _progress(msg: str) -> None:
     """Print progress message to stderr (so stdout stays clean for piping)."""
@@ -72,6 +77,53 @@ def _cache_dir() -> str:
 
 def _cache_path() -> str:
     return os.path.join(_cache_dir(), "MPCORB.DAT")
+
+
+def _format_age(seconds: float) -> str:
+    """Human-readable age from a duration in seconds."""
+    seconds = max(0, int(seconds))
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes = rem // 60
+    if days > 0:
+        return f"{days}d {hours}h"
+    if hours > 0:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def _format_size(num_bytes: int) -> str:
+    """Human-readable file size."""
+    size = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if size < 1024.0 or unit == "GiB":
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{num_bytes} B"
+
+
+def mpcorb_cache_info(path: Optional[str] = None) -> Optional[dict]:
+    """
+    Return metadata about the cached MPCORB.DAT file, or None if missing.
+
+    Keys: path, size_bytes, mtime (datetime), age_seconds, fresh (bool).
+    """
+    if path is None:
+        path = _cache_path()
+    if not os.path.isfile(path):
+        return None
+    st = os.stat(path)
+    mtime = datetime.datetime.fromtimestamp(st.st_mtime)
+    age_seconds = (datetime.datetime.now() - mtime).total_seconds()
+    return {
+        "path": os.path.abspath(path),
+        "size_bytes": st.st_size,
+        "mtime": mtime,
+        "age_seconds": age_seconds,
+        "fresh": age_seconds < MPCORB_MAX_AGE_DAYS * 86400,
+    }
 
 
 def _parse_float(s: str) -> Optional[float]:
@@ -169,24 +221,77 @@ def download_mpcorb(force: bool = False) -> str:
     """
     Download MPCORB.DAT.gz from MPC to local cache. Returns path to cached file
     (gunzipped as MPCORB.DAT).
+
+    Skips the network download when a local cache exists and is younger than
+    MPCORB_MAX_AGE_DAYS, unless force=True. Always prints why download was
+    skipped or performed.
     """
+    def log(msg: str) -> None:
+        print(msg, flush=True)
+
     cache_dir = _cache_dir()
     os.makedirs(cache_dir, exist_ok=True)
     out_path = _cache_path()
-    if not force and os.path.isfile(out_path):
-        return out_path
+    info = mpcorb_cache_info(out_path)
+
+    if info is not None and not force:
+        age_str = _format_age(info["age_seconds"])
+        if info["fresh"]:
+            log(
+                f"Skipping MPC download: cached file is {age_str} old "
+                f"(younger than {MPCORB_MAX_AGE_DAYS} days)."
+            )
+            log(f"  Location: {info['path']}")
+            log(f"  Modified: {info['mtime'].isoformat(sep=' ', timespec='seconds')}")
+            log(f"  Size:     {_format_size(info['size_bytes'])}")
+            log("  Use --force to re-download anyway.")
+            return out_path
+        log(
+            f"Cached MPCORB is {age_str} old "
+            f"(older than {MPCORB_MAX_AGE_DAYS} days); re-downloading from MPC."
+        )
+        log(f"  Existing: {info['path']}")
+    elif info is not None and force:
+        age_str = _format_age(info["age_seconds"])
+        log(
+            f"Forcing re-download (--force). Existing cache is {age_str} old "
+            f"at {info['path']}."
+        )
+    else:
+        log(f"No local MPCORB cache found at {out_path}; downloading from MPC.")
+
     gz_path = out_path + ".gz"
-    print(f"Downloading {MPCORB_URL} ...")
-    urllib.request.urlretrieve(MPCORB_URL, gz_path)
-    with gzip.open(gz_path, "rb") as f_in:
-        with open(out_path, "wb") as f_out:
-            f_out.write(f_in.read())
+    log(f"Downloading {MPCORB_URL} ...")
     try:
-        os.remove(gz_path)
-    except OSError:
-        # Best-effort cleanup: ignore failure to remove temporary .gz file.
-        pass
-    print(f"Cached to {out_path}")
+        urllib.request.urlretrieve(MPCORB_URL, gz_path)
+    except urllib.error.URLError as exc:
+        print(f"ERROR: failed to download MPCORB from {MPCORB_URL}: {exc}",
+              file=sys.stderr, flush=True)
+        raise
+    except OSError as exc:
+        print(f"ERROR: failed to write download to {gz_path}: {exc}",
+              file=sys.stderr, flush=True)
+        raise
+
+    log("Decompressing ...")
+    try:
+        with gzip.open(gz_path, "rb") as f_in:
+            with open(out_path, "wb") as f_out:
+                f_out.write(f_in.read())
+    except OSError as exc:
+        print(f"ERROR: failed to decompress {gz_path}: {exc}",
+              file=sys.stderr, flush=True)
+        raise
+    finally:
+        try:
+            os.remove(gz_path)
+        except OSError:
+            # Best-effort cleanup: ignore failure to remove temporary .gz file.
+            pass
+
+    info_after = mpcorb_cache_info(out_path)
+    size_str = _format_size(info_after["size_bytes"]) if info_after else "?"
+    log(f"Cached to {out_path} ({size_str})")
     return out_path
 
 
@@ -207,6 +312,45 @@ def _asteroid_count_db(conn) -> int:
     out = cursor.fetchone()[0]
     cursor.close()
     return out
+
+
+def _asteroid_db_stats(conn) -> Optional[dict]:
+    """
+    Return aggregate asteroid stats from the DB, or None if the table is missing.
+    """
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            """
+            SELECT
+                count(*) AS total,
+                count(number) AS numbered,
+                count(*) FILTER (WHERE number IS NULL) AS unnumbered,
+                count(absolute_magnitude) AS with_h
+            FROM asteroids
+            """
+        )
+        total, numbered, unnumbered, with_h = cursor.fetchone()
+        stats = {
+            "total": total,
+            "numbered": numbered,
+            "unnumbered": unnumbered,
+            "with_absolute_magnitude": with_h,
+            "tags": None,
+            "tagged_asteroids": None,
+        }
+        # Tag tables exist from schema 24 onward.
+        if db.version_get(conn) >= 24:
+            cursor.execute("SELECT count(*) FROM asteroid_tags")
+            stats["tags"] = cursor.fetchone()[0]
+            cursor.execute("SELECT count(DISTINCT asteroid_id) FROM asteroid_tag_map")
+            stats["tagged_asteroids"] = cursor.fetchone()[0]
+        return stats
+    except BaseException:
+        conn.rollback()
+        return None
+    finally:
+        cursor.close()
 
 
 def load_mpcorb_into_db(conn, path: Optional[str] = None, limit: Optional[int] = None) -> int:
@@ -777,12 +921,98 @@ def compute_asteroid_visibility_curve(
 
 def asteroids_download(args):
     """CLI: download and optionally load MPCORB into DB."""
-    path = download_mpcorb(force=args.force)
-    if args.load:
+    try:
+        path = download_mpcorb(force=getattr(args, "force", False))
+    except (urllib.error.URLError, OSError):
+        return 1
+    if getattr(args, "load", False):
         conn = db.connect()
-        n = load_mpcorb_into_db(conn, path=path, limit=args.limit)
-        conn.close()
+        try:
+            n = load_mpcorb_into_db(conn, path=path, limit=getattr(args, "limit", None))
+            print(f"Loaded {n} asteroids into database.")
+        finally:
+            conn.close()
+    return 0
+
+
+def asteroids_load(args):
+    """CLI: create/update asteroid rows from the cached (or given) MPCORB file."""
+    path = getattr(args, "file", None) or _cache_path()
+    if not os.path.isfile(path):
+        print(
+            f"ERROR: MPCORB not found at {path}.\n"
+            "  Run 'hevelius asteroid download' first, or pass --file PATH.",
+            file=sys.stderr,
+        )
+        return 1
+    info = mpcorb_cache_info(path)
+    if info:
+        print(
+            f"Loading asteroids from {info['path']} "
+            f"({_format_size(info['size_bytes'])}, "
+            f"modified {info['mtime'].isoformat(sep=' ', timespec='seconds')})"
+        )
+    conn = db.connect()
+    try:
+        n = load_mpcorb_into_db(conn, path=path, limit=getattr(args, "limit", None))
         print(f"Loaded {n} asteroids into database.")
+    finally:
+        conn.close()
+    return 0
+
+
+def asteroids_status(args):
+    """CLI: report MPCORB cache freshness and asteroid DB counters."""
+    print("=== MPCORB cache ===")
+    info = mpcorb_cache_info()
+    if info is None:
+        print("  Status:   not downloaded")
+        print(f"  Expected: {_cache_path()}")
+        print("  Run:      hevelius asteroid download")
+    else:
+        fresh_label = (
+            f"yes (younger than {MPCORB_MAX_AGE_DAYS} days)"
+            if info["fresh"]
+            else f"no (older than {MPCORB_MAX_AGE_DAYS} days; re-download recommended)"
+        )
+        print("  Status:   present")
+        print(f"  Location: {info['path']}")
+        print(f"  Size:     {_format_size(info['size_bytes'])}")
+        print(f"  Modified: {info['mtime'].isoformat(sep=' ', timespec='seconds')}")
+        print(f"  Age:      {_format_age(info['age_seconds'])}")
+        print(f"  Fresh:    {fresh_label}")
+        print(f"  Source:   {MPCORB_URL}")
+        if getattr(args, "count_file", False):
+            print("  Counting asteroid records in file...")
+            print(f"  Records:  ~{_count_mpcorb_lines(info['path']):,}")
+
+    print()
+    print("=== Database ===")
+    try:
+        conn = db.connect()
+    except Exception as exc:
+        print(f"  ERROR: could not connect to database: {exc}")
+        return 1
+
+    try:
+        stats = _asteroid_db_stats(conn)
+        if stats is None:
+            print("  asteroids table not found (run DB migrations).")
+            return 1
+        print(f"  Total asteroids:       {stats['total']:,}")
+        print(f"  Numbered:              {stats['numbered']:,}")
+        print(f"  Unnumbered:            {stats['unnumbered']:,}")
+        print(f"  With absolute mag (H): {stats['with_absolute_magnitude']:,}")
+        if stats["tags"] is not None:
+            print(f"  Tags defined:          {stats['tags']:,}")
+            print(f"  Asteroids with tags:   {stats['tagged_asteroids']:,}")
+        else:
+            print("  Tags:                  (asteroid_tags not migrated yet)")
+        if stats["total"] == 0:
+            print("  Tip: run 'hevelius asteroid load' after downloading MPCORB.")
+    finally:
+        conn.close()
+    return 0
 
 
 def asteroids_visible(args):

--- a/hevelius/cmd_asteroid.py
+++ b/hevelius/cmd_asteroid.py
@@ -29,15 +29,8 @@ import numpy as np
 from hevelius import db
 from hevelius.config import load_config
 
-# Recent/future dates need up-to-date Earth orientation (IERS) data, normally
-# auto-downloaded. Without network access (or if the download fails), astropy
-# raises rather than falling back to extrapolated values. The extrapolation
-# error is sub-arcsecond and irrelevant for altitude/visibility purposes, so
-# disable the hard age limit rather than let observation planning fail offline.
-iers.conf.auto_max_age = None
-
 # MPCORB.DAT fixed-width columns (0-based); format from MPC Export Format.
-# Columns 1-7: designation (1-4 packed, 5-7 number or continuation)
+# Columns 1-7: number or provisional designation (packed form)
 # 9-13: H, 15-19: G, 21-25: Epoch, 27-35: M, 38-46: omega, 49-57: Omega,
 # 60-68: i, 71-79: e, 81-91: n, 93-103: a
 MPCORB_COLS = {
@@ -56,8 +49,37 @@ MPCORB_COLS = {
 
 MPCORB_URL = "https://minorplanetcenter.net/iau/MPCORB/MPCORB.DAT.gz"
 
+
 # Skip re-download from MPC when the local cache is younger than this.
 MPCORB_MAX_AGE_DAYS = 7
+
+
+# Base-62 alphabet used in MPC packed permanent designations (>= 620000).
+_BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+_BASE62_INDEX = {c: i for i, c in enumerate(_BASE62)}
+
+_iers_configured_for_planning = False
+
+
+def _configure_iers_for_planning() -> None:
+    """
+    Allow IERS age extrapolation for offline/future observation planning.
+
+    Recent/future dates need up-to-date Earth orientation (IERS) data, normally
+    auto-downloaded. Without network access (or if the download fails), astropy
+    raises rather than falling back to extrapolated values. The extrapolation
+    error is sub-arcsecond and irrelevant for altitude/visibility purposes, so
+    disable the hard age limit when running visibility computations.
+
+    Applied lazily (once per process) from visibility entry points only, so
+    importing this module for MPCORB parsing does not change global IERS
+    behaviour for unrelated astropy callers.
+    """
+    global _iers_configured_for_planning
+    if _iers_configured_for_planning:
+        return
+    iers.conf.auto_max_age = None
+    _iers_configured_for_planning = True
 
 
 def _progress(msg: str) -> None:
@@ -146,6 +168,56 @@ def _parse_int(s: str) -> Optional[int]:
         return None
 
 
+def _unpack_permanent_number(designation: str) -> Optional[int]:
+    """
+    Unpack an MPC packed permanent designation to an integer MPC number.
+
+    Permanent packed forms are documented at
+    https://minorplanetcenter.net/iau/info/PackedDes.html :
+
+      - < 100000: zero-padded digits (e.g. ``00001``, ``00433``)
+      - 100000–619999: letter (A–Z / a–z) + 4 digits (e.g. ``A0345`` → 100345)
+      - ≥ 620000: ``~`` + 4 base-62 chars (e.g. ``~0000`` → 620000)
+
+    Provisional designations (typically 7 characters) and other non-permanent
+    forms return None.
+    """
+    d = designation.strip()
+    if not d:
+        return None
+
+    # Plain numeric permanent numbers (often 5-digit zero-padded in cols 1–7).
+    if d.isdigit():
+        return int(d)
+
+    if len(d) != 5:
+        return None
+
+    first, rest = d[0], d[1:]
+
+    # Letter + 4 digits: A=10 … Z=35, a=36 … z=61 (number DIV 10000).
+    if first.isalpha() and rest.isdigit():
+        if "A" <= first <= "Z":
+            high = ord(first) - ord("A") + 10
+        elif "a" <= first <= "z":
+            high = ord(first) - ord("a") + 36
+        else:
+            return None
+        return high * 10000 + int(rest)
+
+    # Tilde + base-62 encoding of (number - 620000).
+    if first == "~":
+        value = 0
+        for ch in rest:
+            digit = _BASE62_INDEX.get(ch)
+            if digit is None:
+                return None
+            value = value * 62 + digit
+        return 620000 + value
+
+    return None
+
+
 def _unpack_epoch(packed: str) -> float:
     """Convert MPC packed epoch (5 chars, e.g. K22A2) to Julian Date (approximate)."""
     packed = packed.strip()
@@ -184,9 +256,9 @@ def _parse_mpcorb_line(line: str) -> Optional[dict]:
         return None
     try:
         designation = line[MPCORB_COLS["designation"][0]: MPCORB_COLS["designation"][1]].strip()
-        if not designation or designation.startswith("--------"):
+        if not designation or set(designation) == {"-"}:
             return None
-        number = _parse_int(line[4:7])  # columns 5-7 are number for numbered
+        number = _unpack_permanent_number(designation)
         H = _parse_float(line[MPCORB_COLS["H"][0]: MPCORB_COLS["H"][1]])
         G = _parse_float(line[MPCORB_COLS["G"][0]: MPCORB_COLS["G"][1]])
         epoch = line[MPCORB_COLS["epoch"][0]: MPCORB_COLS["epoch"][1]].strip()
@@ -600,6 +672,7 @@ def compute_visibility(
     Returns:
         List of visible asteroids with designation, magnitude, max_altitude, etc.
     """
+    _configure_iers_for_planning()
 
     obs_time = Time(obs_date + " 00:00:00")
 
@@ -852,6 +925,7 @@ def compute_asteroid_visibility_curve(
     (number, designation, epoch_s, M_epoch, peri, node, inc, e, n, a, H, G) = asteroid_row
     G = G if G is not None else 0.15
 
+    _configure_iers_for_planning()
     obs_time = Time(obs_date + " 00:00:00")
     night_start, night_end = _get_night_times(location, obs_time)
     duration_h = (night_end - night_start).to(u.hour).value

--- a/hevelius/cmd_asteroid.py
+++ b/hevelius/cmd_asteroid.py
@@ -597,20 +597,115 @@ def _apparent_magnitude(H: float, G: float, r_au: float, delta_au: float, phase_
     return H + 5 * np.log10(r_au * delta_au) - 2.5 * np.log10(phi)
 
 
-def _get_night_times(location: EarthLocation, obs_time: Time) -> Tuple[Time, Time]:
-    """Return (start, end) of night in UTC (sun 18 deg below horizon)."""
-    from astropy.coordinates import AltAz
-    midnight = obs_time + 0.5 * u.day
-    times = midnight + np.linspace(-12, 12, 200) * u.hour
+def _altitude_series(body_fn, location: EarthLocation, t0: Time, t1: Time, n: int = 481):
+    """
+    Sample altitude (degrees) of a solar-system body from t0 to t1 inclusive.
+
+    body_fn(times) -> SkyCoord (e.g. get_sun, or lambda t: get_body('moon', t)).
+    """
+    duration_h = (t1 - t0).to(u.hour).value
+    times = t0 + np.linspace(0.0, duration_h, n) * u.hour
     frame = AltAz(obstime=times, location=location)
-    sun = get_sun(times)
-    sun_altaz = sun.transform_to(frame)
-    below = np.where(sun_altaz.alt < -18 * u.deg)[0]
-    if len(below) == 0:
-        return midnight - 6 * u.hour, midnight + 6 * u.hour
-    start_idx = below[0]
-    end_idx = below[-1]
-    return times[start_idx], times[end_idx]
+    alt = body_fn(times).transform_to(frame).alt.to(u.deg).value
+    return times, np.asarray(alt, dtype=float)
+
+
+def _find_zero_crossings(times: Time, alts: np.ndarray, level: float = 0.0):
+    """
+    Linearly interpolate times where altitude crosses `level`.
+
+    Returns list of (Time, direction) with direction 'up' or 'down'.
+    """
+    crossings = []
+    for i in range(len(alts) - 1):
+        a0, a1 = alts[i] - level, alts[i + 1] - level
+        if a0 == 0:
+            # Exact hit: infer direction from the next sample when possible.
+            if a1 > 0:
+                crossings.append((times[i], "up"))
+            elif a1 < 0:
+                crossings.append((times[i], "down"))
+            continue
+        if a0 * a1 > 0:
+            continue
+        if a0 * a1 == 0 and a1 == 0:
+            continue
+        frac = abs(a0) / (abs(a0) + abs(a1) + 1e-20)
+        t_cross = times[i] + frac * (times[i + 1] - times[i])
+        crossings.append((t_cross, "up" if a1 > a0 else "down"))
+    return crossings
+
+
+def _get_night_times(location: EarthLocation, obs_time: Time) -> Tuple[Time, Time]:
+    """
+    Return (sunset, sunrise) in UTC for the night beginning on obs_time's date.
+
+    The night runs from geometric sunset (sun altitude crossing 0° downward)
+    on the evening of that calendar date through geometric sunrise the next
+    morning. This matches observer "night" even when astronomical twilight
+    never occurs (e.g. mid-latitude summer).
+
+    If the Sun never sets (polar day), falls back to a 12-hour window centred
+    on local solar midnight as a last resort. If the Sun never rises (polar
+    night), returns noon→next-noon.
+    """
+    # Search from noon UTC on the evening date through noon the next day.
+    date_str = obs_time.iso[:10]
+    noon = Time(f"{date_str} 12:00:00")
+    times, alts = _altitude_series(get_sun, location, noon, noon + 24 * u.hour, n=577)
+    crossings = _find_zero_crossings(times, alts, level=0.0)
+
+    sunset = next((t for t, d in crossings if d == "down"), None)
+    sunrise = None
+    if sunset is not None:
+        sunrise = next((t for t, d in crossings if d == "up" and t > sunset), None)
+
+    if sunset is not None and sunrise is not None and sunrise > sunset:
+        return sunset, sunrise
+
+    # Polar night: sun always below horizon across the window.
+    if np.all(alts < 0):
+        return noon, noon + 24 * u.hour
+
+    # Polar day / no clear night: last-resort evening-centred window (NOT daytime).
+    midnight = noon + 12 * u.hour
+    return midnight - 6 * u.hour, midnight + 6 * u.hour
+
+
+def _moon_rise_set(location: EarthLocation, night_start: Time, night_end: Time):
+    """
+    Find moonrise/moonset near the given night.
+
+    Searches a padded window around the night so events just outside sunset/
+    sunrise are still reported. Returns (moonrise, moonset) as Time or None.
+    """
+    pad = 6 * u.hour
+    times, alts = _altitude_series(
+        lambda t: get_body("moon", t),
+        location,
+        night_start - pad,
+        night_end + pad,
+        n=721,
+    )
+    crossings = _find_zero_crossings(times, alts, level=0.0)
+    rises = [t for t, d in crossings if d == "up"]
+    sets = [t for t, d in crossings if d == "down"]
+
+    moonrise = next((r for r in rises if r <= night_end + pad), None)
+    moonset = None
+    if moonrise is not None:
+        moonset = next((s for s in sets if s > moonrise), None)
+    elif sets:
+        # Moon already up at window start: report the upcoming set.
+        moonset = sets[0]
+
+    return moonrise, moonset
+
+
+def _moon_altitudes(location: EarthLocation, times: Time) -> np.ndarray:
+    """Moon altitude in degrees at each sample time."""
+    frame = AltAz(obstime=times, location=location)
+    return get_body("moon", times).transform_to(frame).alt.to(u.deg).value
 
 
 def _xyz_to_radec(x: float, y: float, z: float) -> Tuple[float, float]:
@@ -964,6 +1059,8 @@ def compute_asteroid_visibility_curve(
 
     with solar_system_ephemeris.set("builtin"):
         earth_positions = get_body("earth", times)
+        moon_alt = _moon_altitudes(location, times)
+        moonrise, moonset = _moon_rise_set(location, night_start, night_end)
     ex = earth_positions.cartesian.x.to(u.AU).value
     ey = earth_positions.cartesian.y.to(u.AU).value
     ez = earth_positions.cartesian.z.to(u.AU).value
@@ -1005,6 +1102,8 @@ def compute_asteroid_visibility_curve(
             "altitude_deg": round(float(alt_deg[i]), 2),
             "azimuth_deg": round(float(az_deg[i]), 2),
             "apparent_magnitude": round(mag, 2) if mag is not None else None,
+            "moon_up": bool(moon_alt[i] > 0),
+            "moon_altitude_deg": round(float(moon_alt[i]), 2),
         })
 
     max_idx = int(np.argmax(alt_deg))
@@ -1012,6 +1111,10 @@ def compute_asteroid_visibility_curve(
     return {
         "night_start": night_start.iso,
         "night_end": night_end.iso,
+        "sunset": night_start.iso,
+        "sunrise": night_end.iso,
+        "moonrise": moonrise.iso if moonrise is not None else None,
+        "moonset": moonset.iso if moonset is not None else None,
         "samples": samples,
         "max_altitude_deg": round(float(alt_deg[max_idx]), 2),
         "max_altitude_time": times[max_idx].iso,
@@ -1159,6 +1262,190 @@ def _format_asteroid_title(number, designation, name) -> str:
     return designation
 
 
+def _resample_series(values, width: int):
+    """Pick `width` evenly spaced samples from a sequence."""
+    if width <= 0 or not values:
+        return []
+    if len(values) == 1:
+        return [values[0]] * width
+    if len(values) <= width:
+        return list(values)
+    out = []
+    last = len(values) - 1
+    for i in range(width):
+        idx = int(round(i * last / (width - 1)))
+        out.append(values[idx])
+    return out
+
+
+def _format_hhmm(iso_time: str) -> str:
+    """Extract HH:MM from an astropy/ISO timestamp string."""
+    # Examples: "2026-07-22 20:15:00.000" or "2026-07-22 20:15:00.000000"
+    parts = iso_time.strip().split()
+    if len(parts) < 2:
+        return iso_time
+    return parts[1][:5]
+
+
+def render_altitude_chart(
+    samples,
+    width: int = 56,
+    height: int = 12,
+    alt_min: float = -30.0,
+    alt_max: float = 90.0,
+    color: bool = False,
+) -> List[str]:
+    """
+    Render a night altitude curve as Unicode block-chart lines.
+
+    When a sample has moon_up=True, the marker/stem for that column is drawn
+    in yellow (if color is enabled). Returns a list of printable lines.
+    """
+    if not samples:
+        return ["  (no visibility samples)"]
+
+    alts = _resample_series([s["altitude_deg"] for s in samples], width)
+    times = _resample_series([s["time"] for s in samples], width)
+    moon_up = _resample_series([bool(s.get("moon_up")) for s in samples], width)
+    span = alt_max - alt_min
+    if span <= 0:
+        span = 1.0
+
+    # Grid of characters: height rows x width cols
+    grid = [[" "] * width for _ in range(height)]
+    horizon_row = None
+    if alt_min <= 0 <= alt_max:
+        horizon_row = int(round((alt_max - 0.0) / span * (height - 1)))
+        horizon_row = max(0, min(height - 1, horizon_row))
+        for c in range(width):
+            grid[horizon_row][c] = "─"
+
+    point_rows = [0] * width
+    for c, alt in enumerate(alts):
+        clipped = max(alt_min, min(alt_max, float(alt)))
+        row = int(round((alt_max - clipped) / span * (height - 1)))
+        row = max(0, min(height - 1, row))
+        point_rows[c] = row
+        if horizon_row is not None:
+            lo, hi = sorted((row, horizon_row))
+            for r in range(lo, hi + 1):
+                if grid[r][c] == "─":
+                    continue
+                grid[r][c] = "│" if r != row else "●"
+        grid[row][c] = "●"
+
+    def dim(s):
+        return _ansi("2", s, color)
+
+    def cyan(s):
+        return _ansi("36", s, color)
+
+    def green(s):
+        return _ansi("32", s, color)
+
+    def yellow(s):
+        return _ansi("33", s, color)
+
+    lines = []
+    label_w = 4
+    for r in range(height):
+        alt_label = alt_max - (r / (height - 1)) * span
+        label = f"{alt_label:4.0f}"
+        row_chars = []
+        for c, ch in enumerate(grid[r]):
+            if ch == "●":
+                paint = yellow if moon_up[c] else green
+                row_chars.append(paint(ch) if color else ch)
+            elif ch == "│":
+                paint = yellow if moon_up[c] else cyan
+                row_chars.append(paint(ch) if color else ch)
+            elif ch == "─":
+                row_chars.append(dim(ch) if color else ch)
+            else:
+                row_chars.append(ch)
+        suffix = "  horizon" if horizon_row is not None and r == horizon_row else ""
+        lines.append(f"  {dim(label)}│{''.join(row_chars)}{dim(suffix)}")
+
+    axis = " " * label_w + "└" + "─" * width
+    lines.append("  " + (dim(axis) if color else axis))
+
+    t_start = _format_hhmm(times[0])
+    t_mid = _format_hhmm(times[len(times) // 2])
+    t_end = _format_hhmm(times[-1])
+    pad = width
+    labels_line = [" "] * pad
+    for text, pos in ((t_start, 0), (t_mid, pad // 2 - len(t_mid) // 2), (t_end, pad - len(t_end))):
+        pos = max(0, min(pad - len(text), pos))
+        for i, ch in enumerate(text):
+            labels_line[pos + i] = ch
+    time_row = "".join(labels_line)
+    lines.append("  " + (" " * label_w) + " " + (dim(time_row) if color else time_row))
+    if color:
+        lines.append(
+            "  " + (" " * label_w) + " "
+            + green("●") + dim(" asteroid  ")
+            + yellow("●") + dim(" asteroid + moon up")
+        )
+    return lines
+
+
+def _fmt_event(iso_or_none) -> str:
+    if not iso_or_none:
+        return "—"
+    return _format_hhmm(iso_or_none)
+
+
+def _print_visibility_section(curve, scope_id, scope_name, lat, lon, alt, obs_date, color: bool) -> None:
+    """Print visibility summary + altitude chart for one asteroid/telescope/night."""
+
+    def bold(s):
+        return _ansi("1", s, color)
+
+    def cyan(s):
+        return _ansi("36", s, color)
+
+    def dim(s):
+        return _ansi("2", s, color)
+
+    def yellow(s):
+        return _ansi("33", s, color)
+
+    def green(s):
+        return _ansi("32", s, color)
+
+    def red(s):
+        return _ansi("31", s, color)
+
+    label = scope_name or f"scope_id={scope_id}"
+    print(f"  {yellow(bold('Visibility'))}  {cyan(label)} {dim(f'(scope_id={scope_id})')}")
+    print(f"  {dim('Site')}                  {lat:.4f}°, {lon:.4f}°  alt {alt:.0f} m")
+    print(f"  {dim('Evening date')}          {obs_date}")
+    print(
+        f"  {dim('Night (UTC)')}           "
+        f"{_fmt_event(curve.get('sunset') or curve['night_start'])} → "
+        f"{_fmt_event(curve.get('sunrise') or curve['night_end'])}"
+    )
+    print(f"  {dim('Sunset')}                {_fmt_event(curve.get('sunset') or curve['night_start'])} UTC")
+    print(f"  {dim('Sunrise')}               {_fmt_event(curve.get('sunrise') or curve['night_end'])} UTC")
+    print(f"  {dim('Moonrise')}              {_fmt_event(curve.get('moonrise'))} UTC")
+    print(f"  {dim('Moonset')}               {_fmt_event(curve.get('moonset'))} UTC")
+    print(
+        f"  {dim('Max altitude')}          {curve['max_altitude_deg']:.1f}° "
+        f"at {_format_hhmm(curve['max_altitude_time'])}"
+    )
+    if curve.get("has_magnitude_estimate") and curve.get("apparent_magnitude_at_max") is not None:
+        print(f"  {dim('Apparent mag @ max')}   {curve['apparent_magnitude_at_max']:.2f}")
+    else:
+        print(f"  {dim('Apparent mag @ max')}   {dim('— (no H)')}")
+    visible = curve.get("visible")
+    vis_label = green("yes") if visible else red("no")
+    print(f"  {dim('Above horizon')}         {vis_label}")
+    print()
+    for line in render_altitude_chart(curve.get("samples") or [], color=color):
+        print(line)
+    print()
+
+
 def _print_asteroid_detail(row, tags, color: bool) -> None:
     """Pretty-print one asteroid row (full SELECT shape) plus optional tags."""
     (asteroid_id, number, designation, name, epoch, mean_anomaly, perihelion_arg,
@@ -1240,6 +1527,9 @@ def asteroids_show(args):
 
     color = not getattr(args, "no_color", False) and sys.stdout.isatty()
     limit = int(getattr(args, "limit", 20) or 20)
+    telescope_id = getattr(args, "telescope_id", None)
+    telescope_name = getattr(args, "telescope", None)
+    want_visibility = telescope_id is not None or bool(telescope_name)
 
     try:
         conn = db.connect()
@@ -1275,6 +1565,30 @@ def asteroids_show(args):
 
         tags = db.asteroid_tags_for_asteroids(conn, [rows[0][0]]).get(rows[0][0], [])
         _print_asteroid_detail(rows[0], tags, color=color)
+
+        if not want_visibility:
+            return 0
+
+        try:
+            scope_id, scope_name, lat, lon, alt = db.telescope_resolve(
+                conn, scope_id=telescope_id, name=telescope_name,
+            )
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+
+        from datetime import date as date_cls
+        obs_date = getattr(args, "date", None) or date_cls.today().isoformat()
+        step_minutes = int(getattr(args, "step_minutes", 10) or 10)
+        location = EarthLocation(lat=lat * u.deg, lon=lon * u.deg, height=alt * u.m)
+
+        # Row without internal id — matches compute_asteroid_visibility_curve contract.
+        curve = compute_asteroid_visibility_curve(
+            rows[0][1:], location, obs_date, step_minutes=step_minutes,
+        )
+        _print_visibility_section(
+            curve, scope_id, scope_name, lat, lon, alt, obs_date, color=color,
+        )
         return 0
     finally:
         conn.close()

--- a/hevelius/cmd_asteroid.py
+++ b/hevelius/cmd_asteroid.py
@@ -60,8 +60,6 @@ MPCORB_MAX_AGE_DAYS = 7
 _BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 _BASE62_INDEX = {c: i for i, c in enumerate(_BASE62)}
 
-_iers_configured_for_planning = False
-
 
 def _configure_iers_for_planning() -> None:
     """
@@ -73,15 +71,13 @@ def _configure_iers_for_planning() -> None:
     error is sub-arcsecond and irrelevant for altitude/visibility purposes, so
     disable the hard age limit when running visibility computations.
 
-    Applied lazily (once per process) from visibility entry points only, so
-    importing this module for MPCORB parsing does not change global IERS
-    behaviour for unrelated astropy callers.
+    Applied lazily from visibility entry points only (idempotent via the
+    auto_max_age sentinel), so importing this module for MPCORB parsing does
+    not change global IERS behaviour for unrelated astropy callers.
     """
-    global _iers_configured_for_planning
-    if _iers_configured_for_planning:
+    if iers.conf.auto_max_age is None:
         return
     iers.conf.auto_max_age = None
-    _iers_configured_for_planning = True
 
 
 def _progress(msg: str) -> None:
@@ -444,7 +440,8 @@ def _asteroid_db_stats(conn) -> Optional[dict]:
             cursor.execute("SELECT count(DISTINCT asteroid_id) FROM asteroid_tag_map")
             stats["tagged_asteroids"] = cursor.fetchone()[0]
         return stats
-    except BaseException:
+    except Exception:
+        # asteroids / tag tables may be missing on older schemas
         conn.rollback()
         return None
     finally:

--- a/hevelius/cmd_asteroid.py
+++ b/hevelius/cmd_asteroid.py
@@ -1245,6 +1245,130 @@ def asteroids_visible(args):
     return len(results)
 
 
+_LIST_SORT_FIELDS = (
+    "number", "name", "designation", "absolute_magnitude",
+    "semimajor_axis", "eccentricity", "inclination", "mean_motion", "epoch",
+)
+
+
+def asteroids_list(args):
+    """
+    CLI: paginated catalogue listing with filters and sorting.
+
+    Defaults: first 100 rows, sorted by MPC number ascending.
+    """
+    sort_by = getattr(args, "sort_by", None) or "number"
+    sort_order = getattr(args, "sort_order", None) or "asc"
+    if sort_by not in _LIST_SORT_FIELDS:
+        print(
+            f"ERROR: invalid --sort-by {sort_by!r}. "
+            f"Choose from: {', '.join(_LIST_SORT_FIELDS)}",
+            file=sys.stderr,
+        )
+        return 1
+    if sort_order not in ("asc", "desc"):
+        print("ERROR: --sort-order must be 'asc' or 'desc'.", file=sys.stderr)
+        return 1
+
+    limit = getattr(args, "limit", 100)
+    if limit is None or limit < 1:
+        print("ERROR: --limit must be a positive integer.", file=sys.stderr)
+        return 1
+    offset = getattr(args, "offset", 0) or 0
+    if offset < 0:
+        print("ERROR: --offset must be >= 0.", file=sys.stderr)
+        return 1
+
+    numbered = getattr(args, "numbered", None)
+    if getattr(args, "unnumbered", False):
+        if numbered is True:
+            print("ERROR: use only one of --numbered / --unnumbered.", file=sys.stderr)
+            return 1
+        numbered = False
+
+    mag_min = getattr(args, "mag_min", None)
+    mag_max = getattr(args, "mag_max", None)
+    if mag_min is not None and mag_max is not None and mag_min > mag_max:
+        print("ERROR: --mag-min must be <= --mag-max.", file=sys.stderr)
+        return 1
+
+    tag_raw = getattr(args, "tags", None)
+    tag_names = None
+    if tag_raw:
+        tag_names = [t.strip() for t in tag_raw.split(",") if t.strip()] or None
+    tags_mode = getattr(args, "tags_mode", None) or "any"
+
+    try:
+        conn = db.connect()
+    except Exception as exc:
+        print(f"ERROR: could not connect to database: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        filters = dict(
+            designation=getattr(args, "designation", None) or None,
+            name=getattr(args, "name", None) or None,
+            number=getattr(args, "number", None),
+            numbered=numbered,
+            mag_min=mag_min,
+            mag_max=mag_max,
+            tag_names=tag_names,
+            tags_mode=tags_mode,
+        )
+        total = db.asteroids_count(conn, **filters)
+        rows = db.asteroids_search(
+            conn,
+            **filters,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            limit=limit,
+            offset=offset,
+        )
+    finally:
+        conn.close()
+
+    color = not getattr(args, "no_color", False) and sys.stdout.isatty()
+
+    def dim(s):
+        return _ansi("2", s, color)
+
+    def bold(s):
+        return _ansi("1", s, color)
+
+    shown = len(rows or [])
+    end = offset + shown
+    print(
+        bold("Asteroids")
+        + dim(f"  showing {offset + 1 if shown else 0}–{end} of {total:,}")
+        + dim(f"  sort={sort_by} {sort_order}")
+    )
+    print(
+        f"{'Number':>8}  {'Name':<20}  {'Designation':<12}  {'H':>6}  "
+        f"{'a (AU)':>8}  {'e':>7}  {'i (°)':>7}"
+    )
+    print(dim("-" * 82))
+
+    if not rows:
+        print(dim("  (no matches)"))
+        return 0
+
+    for row in rows:
+        # id, number, designation, name, epoch, M, peri, node, i, e, n, a, H, G
+        _id, number, designation, name, _epoch, _M, _peri, _node, inc, ecc, _n, a, H, _G = row
+        num = f"{number}" if number is not None else "—"
+        nm = (name or "—")[:20]
+        des = (designation or "")[:12]
+        h = f"{H:.2f}" if H is not None else "—"
+        a_s = f"{a:.4f}" if a is not None else "—"
+        e_s = f"{ecc:.5f}" if ecc is not None else "—"
+        i_s = f"{inc:.2f}" if inc is not None else "—"
+        print(f"{num:>8}  {nm:<20}  {des:<12}  {h:>6}  {a_s:>8}  {e_s:>7}  {i_s:>7}")
+
+    if end < total:
+        print(dim(f"  … {total - end:,} more (use --offset {end} or raise --limit)"))
+    return 0
+
+
 def _ansi(code: str, text: str, enabled: bool) -> str:
     """Wrap text in an ANSI SGR sequence when color is enabled."""
     if not enabled:

--- a/hevelius/cmd_asteroid.py
+++ b/hevelius/cmd_asteroid.py
@@ -33,6 +33,7 @@ from hevelius.config import load_config
 # Columns 1-7: number or provisional designation (packed form)
 # 9-13: H, 15-19: G, 21-25: Epoch, 27-35: M, 38-46: omega, 49-57: Omega,
 # 60-68: i, 71-79: e, 81-91: n, 93-103: a
+# 167-194: readable designation (may include proper name, e.g. "(1) Ceres")
 MPCORB_COLS = {
     "designation": (0, 7),
     "H": (8, 13),
@@ -45,6 +46,7 @@ MPCORB_COLS = {
     "eccentricity": (70, 79),
     "mean_motion": (80, 91),
     "semimajor_axis": (92, 103),
+    "readable_designation": (166, 194),
 }
 
 MPCORB_URL = "https://minorplanetcenter.net/iau/MPCORB/MPCORB.DAT.gz"
@@ -250,6 +252,25 @@ def _unpack_epoch(packed: str) -> float:
         return 2451545.0
 
 
+def _extract_name_from_readable(readable: str) -> Optional[str]:
+    """
+    Extract the proper name from an MPC readable designation field.
+
+    Examples from MPCORB columns 167–194:
+      ``(1) Ceres`` → ``Ceres``
+      ``(433) Eros`` → ``Eros``
+      ``1960 SB1`` → None (provisional, no permanent name)
+    """
+    s = readable.strip()
+    if not s:
+        return None
+    match = re.match(r"^\(\d+\)\s+(.+)$", s)
+    if not match:
+        return None
+    name = match.group(1).strip()
+    return name[:64] if name else None
+
+
 def _parse_mpcorb_line(line: str) -> Optional[dict]:
     """Parse one line of MPCORB.DAT; return dict of fields or None if invalid."""
     if len(line) < 104:
@@ -271,9 +292,14 @@ def _parse_mpcorb_line(line: str) -> Optional[dict]:
         a = _parse_float(line[MPCORB_COLS["semimajor_axis"][0]: MPCORB_COLS["semimajor_axis"][1]])
         if M is None or peri is None or node is None or inc is None or e is None or n is None or a is None:
             return None
+        name = None
+        rd0, rd1 = MPCORB_COLS["readable_designation"]
+        if len(line) >= rd1:
+            name = _extract_name_from_readable(line[rd0:rd1])
         return {
             "number": number,
             "designation": designation[:32],
+            "name": name,
             "epoch": epoch[:16],
             "mean_anomaly": M,
             "perihelion_arg": peri,
@@ -455,17 +481,18 @@ def load_mpcorb_into_db(conn, path: Optional[str] = None, limit: Optional[int] =
                 cursor.execute(
                     """
                     INSERT INTO asteroids (
-                        number, designation, epoch, mean_anomaly, perihelion_arg,
+                        number, designation, name, epoch, mean_anomaly, perihelion_arg,
                         ascending_node, inclination, eccentricity, mean_motion,
                         semimajor_axis, absolute_magnitude, slope_parameter
                     ) VALUES (
-                        %(number)s, %(designation)s, %(epoch)s, %(mean_anomaly)s,
+                        %(number)s, %(designation)s, %(name)s, %(epoch)s, %(mean_anomaly)s,
                         %(perihelion_arg)s, %(ascending_node)s, %(inclination)s,
                         %(eccentricity)s, %(mean_motion)s, %(semimajor_axis)s,
                         %(absolute_magnitude)s, %(slope_parameter)s
                     )
                     ON CONFLICT (designation) DO UPDATE SET
                         number = EXCLUDED.number,
+                        name = EXCLUDED.name,
                         epoch = EXCLUDED.epoch,
                         mean_anomaly = EXCLUDED.mean_anomaly,
                         perihelion_arg = EXCLUDED.perihelion_arg,
@@ -752,7 +779,7 @@ def compute_visibility(
             order_clause = '"' + tokens[0] + '"' + direction
 
     query = (
-        "SELECT number, designation, epoch, mean_anomaly, perihelion_arg, "
+        "SELECT number, designation, name, epoch, mean_anomaly, perihelion_arg, "
         "ascending_node, inclination, eccentricity, mean_motion, "
         "semimajor_axis, absolute_magnitude, slope_parameter "
         "FROM asteroids WHERE " + " AND ".join(where_parts) + " ORDER BY " + order_clause
@@ -776,7 +803,7 @@ def compute_visibility(
             break
 
         for row in rows:
-            (number, designation, epoch_s, M_epoch, peri, node, inc, e, n, a, H, G) = row
+            (number, designation, name, epoch_s, M_epoch, peri, node, inc, e, n, a, H, G) = row
             total_checked += 1
 
             if total_checked % PROGRESS_EVERY == 0:
@@ -877,6 +904,7 @@ def compute_visibility(
             visible.append({
                 "number": number,
                 "designation": designation,
+                "name": name,
                 "absolute_magnitude": H,
                 "apparent_magnitude": round(mag, 2),
                 "max_altitude_deg": round(alt_deg, 2),
@@ -906,7 +934,7 @@ def compute_asteroid_visibility_curve(
     orbital mechanics live here rather than being duplicated in a client.
 
     Args:
-        asteroid_row: (number, designation, epoch, mean_anomaly, perihelion_arg,
+        asteroid_row: (number, designation, name, epoch, mean_anomaly, perihelion_arg,
             ascending_node, inclination, eccentricity, mean_motion,
             semimajor_axis, absolute_magnitude, slope_parameter) as stored in
             the asteroids table (i.e. the row without its internal id).
@@ -922,7 +950,7 @@ def compute_asteroid_visibility_curve(
         above the geometric horizon), and has_magnitude_estimate (whether H
         was available to estimate apparent magnitude).
     """
-    (number, designation, epoch_s, M_epoch, peri, node, inc, e, n, a, H, G) = asteroid_row
+    (number, designation, _name, epoch_s, M_epoch, peri, node, inc, e, n, a, H, G) = asteroid_row
     G = G if G is not None else 0.15
 
     _configure_iers_for_planning()
@@ -1108,6 +1136,145 @@ def asteroids_visible(args):
     print(f"Found {len(results)} visible asteroid(s)")
     for r in results:
         num = r["number"] or ""
-        print(f"  {num:>6} {r['designation']:<12} mag={r['apparent_magnitude']:.2f} "
+        label = r.get("name") or r["designation"]
+        print(f"  {num:>6} {label:<20} mag={r['apparent_magnitude']:.2f} "
               f"max_alt={r['max_altitude_deg']:.1f}° at {r['max_altitude_time']}")
     return len(results)
+
+
+def _ansi(code: str, text: str, enabled: bool) -> str:
+    """Wrap text in an ANSI SGR sequence when color is enabled."""
+    if not enabled:
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def _format_asteroid_title(number, designation, name) -> str:
+    if number is not None and name:
+        return f"({number}) {name}"
+    if number is not None:
+        return f"({number})"
+    if name:
+        return name
+    return designation
+
+
+def _print_asteroid_detail(row, tags, color: bool) -> None:
+    """Pretty-print one asteroid row (full SELECT shape) plus optional tags."""
+    (asteroid_id, number, designation, name, epoch, mean_anomaly, perihelion_arg,
+     ascending_node, inclination, eccentricity, mean_motion, semimajor_axis,
+     absolute_magnitude, slope_parameter) = row
+
+    def bold(s):
+        return _ansi("1", s, color)
+
+    def cyan(s):
+        return _ansi("36", s, color)
+
+    def dim(s):
+        return _ansi("2", s, color)
+
+    def yellow(s):
+        return _ansi("33", s, color)
+
+    def green(s):
+        return _ansi("32", s, color)
+
+    title = _format_asteroid_title(number, designation, name)
+    width = max(48, len(title) + 8)
+    rule = "─" * width
+
+    print()
+    print(cyan(bold(f"  {title}")))
+    print(dim(f"  {rule}"))
+
+    def field(label: str, value) -> None:
+        print(f"  {dim(f'{label:<22}')} {value}")
+
+    field("Database ID", asteroid_id)
+    field("MPC number", number if number is not None else dim("—"))
+    field("Proper name", name if name else dim("— (unnamed)"))
+    field("Packed designation", designation)
+    field("Epoch (packed)", epoch)
+
+    print()
+    print(f"  {yellow(bold('Orbital elements'))}")
+    field("Semi-major axis a", f"{semimajor_axis:.7f} AU")
+    field("Eccentricity e", f"{eccentricity:.7f}")
+    field("Inclination i", f"{inclination:.5f}°")
+    field("Ascending node Ω", f"{ascending_node:.5f}°")
+    field("Perihelion arg ω", f"{perihelion_arg:.5f}°")
+    field("Mean anomaly M", f"{mean_anomaly:.5f}°")
+    field("Mean motion n", f"{mean_motion:.8f} °/day")
+
+    print()
+    print(f"  {yellow(bold('Photometry'))}")
+    if absolute_magnitude is not None:
+        field("Absolute mag H", f"{absolute_magnitude:.2f}")
+    else:
+        field("Absolute mag H", dim("—"))
+    if slope_parameter is not None:
+        field("Slope param G", f"{slope_parameter:.2f}")
+    else:
+        field("Slope param G", dim("—"))
+
+    print()
+    print(f"  {yellow(bold('Tags'))}")
+    if tags:
+        for tag in tags:
+            tag_color = tag.get("color")
+            color_hint = f" {dim(f'[{tag_color}]')}" if tag_color else ""
+            desc = f" — {tag['description']}" if tag.get("description") else ""
+            print(f"  {green('•')} {tag['name']}{color_hint}{desc}")
+    else:
+        print(f"  {dim('(none)')}")
+    print()
+
+
+def asteroids_show(args):
+    """CLI: show detailed info for an asteroid looked up by name/number/designation."""
+    query = (args.query or "").strip()
+    if not query:
+        print("ERROR: provide a name, MPC number, or packed designation.", file=sys.stderr)
+        return 1
+
+    color = not getattr(args, "no_color", False) and sys.stdout.isatty()
+    limit = int(getattr(args, "limit", 20) or 20)
+
+    try:
+        conn = db.connect()
+    except Exception as exc:
+        print(f"ERROR: could not connect to database: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        rows = db.asteroids_find_by_query(conn, query, limit=limit)
+        if not rows:
+            print(f"No asteroid matching {query!r}.")
+            return 1
+
+        if len(rows) > 1:
+            def bold(s):
+                return _ansi("1", s, color)
+
+            def dim(s):
+                return _ansi("2", s, color)
+
+            print(bold(f"Multiple matches for {query!r} (showing up to {limit}):"))
+            print(dim("  Refine with an exact name, number, or packed designation."))
+            print()
+            print(f"  {'Number':>8}  {'Name':<20}  {'Designation':<12}  {'H':>6}  id")
+            for row in rows:
+                _id, number, designation, name, *_rest, H, _G = row
+                num = f"{number}" if number is not None else "—"
+                nm = name or "—"
+                h = f"{H:.2f}" if H is not None else "—"
+                print(f"  {num:>8}  {nm:<20}  {designation:<12}  {h:>6}  {_id}")
+            print()
+            return 0
+
+        tags = db.asteroid_tags_for_asteroids(conn, [rows[0][0]]).get(rows[0][0], [])
+        _print_asteroid_detail(rows[0], tags, color=color)
+        return 0
+    finally:
+        conn.close()

--- a/hevelius/cmd_asteroid.py
+++ b/hevelius/cmd_asteroid.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Tuple
 
 from astropy.coordinates import (
     AltAz,
+    CartesianRepresentation,
     EarthLocation,
     GCRS,
     get_body,
@@ -20,10 +21,18 @@ from astropy.coordinates import (
 )
 from astropy.time import Time
 from astropy import units as u
+from astropy.utils import iers
 import numpy as np
 
 from hevelius import db
 from hevelius.config import load_config
+
+# Recent/future dates need up-to-date Earth orientation (IERS) data, normally
+# auto-downloaded. Without network access (or if the download fails), astropy
+# raises rather than falling back to extrapolated values. The extrapolation
+# error is sub-arcsecond and irrelevant for altitude/visibility purposes, so
+# disable the hard age limit rather than let observation planning fail offline.
+iers.conf.auto_max_age = None
 
 # MPCORB.DAT fixed-width columns (0-based); format from MPC Export Format.
 # Columns 1-7: designation (1-4 packed, 5-7 number or continuation)
@@ -447,7 +456,6 @@ def compute_visibility(
     Returns:
         List of visible asteroids with designation, magnitude, max_altitude, etc.
     """
-    from astropy.coordinates import CartesianRepresentation
 
     obs_time = Time(obs_date + " 00:00:00")
 
@@ -667,6 +675,104 @@ def compute_visibility(
         f"visible: {len(visible)}"
     )
     return visible
+
+
+def compute_asteroid_visibility_curve(
+    asteroid_row: Tuple,
+    location: EarthLocation,
+    obs_date: str,
+    step_minutes: int = 10,
+) -> dict:
+    """
+    Compute a full-night altitude/azimuth/magnitude curve for a single asteroid
+    at a given site. Shared by the web API and (eventually) the CLI, so the
+    orbital mechanics live here rather than being duplicated in a client.
+
+    Args:
+        asteroid_row: (number, designation, epoch, mean_anomaly, perihelion_arg,
+            ascending_node, inclination, eccentricity, mean_motion,
+            semimajor_axis, absolute_magnitude, slope_parameter) as stored in
+            the asteroids table (i.e. the row without its internal id).
+        location: Observer location.
+        obs_date: Night to compute, as the evening date (YYYY-MM-DD); the
+            night runs from that evening into the following morning.
+        step_minutes: Sampling interval across the night.
+
+    Returns:
+        dict with night_start/night_end (ISO), samples (list of
+        {time, altitude_deg, azimuth_deg, apparent_magnitude}), max_altitude_deg,
+        max_altitude_time, apparent_magnitude_at_max, visible (max altitude
+        above the geometric horizon), and has_magnitude_estimate (whether H
+        was available to estimate apparent magnitude).
+    """
+    (number, designation, epoch_s, M_epoch, peri, node, inc, e, n, a, H, G) = asteroid_row
+    G = G if G is not None else 0.15
+
+    obs_time = Time(obs_date + " 00:00:00")
+    night_start, night_end = _get_night_times(location, obs_time)
+    duration_h = (night_end - night_start).to(u.hour).value
+    n_samples = max(2, int(duration_h * 60 / step_minutes) + 1)
+    times = night_start + np.linspace(0, duration_h, n_samples) * u.hour
+
+    epoch_jd = _unpack_epoch(epoch_s)
+
+    with solar_system_ephemeris.set("builtin"):
+        earth_positions = get_body("earth", times)
+    ex = earth_positions.cartesian.x.to(u.AU).value
+    ey = earth_positions.cartesian.y.to(u.AU).value
+    ez = earth_positions.cartesian.z.to(u.AU).value
+
+    geo_x = np.empty(n_samples)
+    geo_y = np.empty(n_samples)
+    geo_z = np.empty(n_samples)
+    magnitudes: List[Optional[float]] = [None] * n_samples
+
+    for i, t in enumerate(times):
+        x, y, z = _orbit_position_at_jd(
+            epoch_jd, float(a), float(e), float(inc), float(node),
+            float(peri), float(M_epoch), float(n), t.jd,
+        )
+        xe, ye, ze = _ecliptic_to_equatorial(x, y, z)
+        gx, gy, gz = xe - ex[i], ye - ey[i], ze - ez[i]
+        geo_x[i], geo_y[i], geo_z[i] = gx, gy, gz
+
+        if H is not None:
+            r_au = np.sqrt(x * x + y * y + z * z)
+            delta_au = np.sqrt(gx * gx + gy * gy + gz * gz)
+            cos_phase = (x * gx + y * gy + z * gz) / (r_au * delta_au + 1e-20)
+            phase_deg = np.degrees(np.arccos(np.clip(cos_phase, -1, 1)))
+            magnitudes[i] = _apparent_magnitude(H, G, r_au, delta_au, phase_deg)
+
+    gcrs = GCRS(
+        CartesianRepresentation(geo_x * u.AU, geo_y * u.AU, geo_z * u.AU),
+        obstime=times,
+    )
+    altaz = gcrs.transform_to(AltAz(obstime=times, location=location))
+    alt_deg = altaz.alt.to(u.deg).value
+    az_deg = altaz.az.to(u.deg).value
+
+    samples = []
+    for i, t in enumerate(times):
+        mag = magnitudes[i]
+        samples.append({
+            "time": t.iso,
+            "altitude_deg": round(float(alt_deg[i]), 2),
+            "azimuth_deg": round(float(az_deg[i]), 2),
+            "apparent_magnitude": round(mag, 2) if mag is not None else None,
+        })
+
+    max_idx = int(np.argmax(alt_deg))
+
+    return {
+        "night_start": night_start.iso,
+        "night_end": night_end.iso,
+        "samples": samples,
+        "max_altitude_deg": round(float(alt_deg[max_idx]), 2),
+        "max_altitude_time": times[max_idx].iso,
+        "apparent_magnitude_at_max": samples[max_idx]["apparent_magnitude"],
+        "visible": bool(alt_deg[max_idx] > 0),
+        "has_magnitude_estimate": H is not None,
+    }
 
 
 def asteroids_download(args):

--- a/hevelius/db.py
+++ b/hevelius/db.py
@@ -471,6 +471,116 @@ def catalog_objects_search(
     return run_query(conn, query, tuple(params) if params else None)
 
 
+ASTEROID_SORT_FIELDS = {
+    "number", "designation", "absolute_magnitude", "semimajor_axis",
+    "eccentricity", "inclination", "mean_motion", "epoch",
+}
+
+_ASTEROID_SELECT = """
+    SELECT id, number, designation, epoch, mean_anomaly, perihelion_arg,
+           ascending_node, inclination, eccentricity, mean_motion,
+           semimajor_axis, absolute_magnitude, slope_parameter
+    FROM asteroids
+"""
+
+
+def asteroids_build_where(
+    designation: str = None,
+    number: int = None,
+    numbered: bool = None,
+    mag_min: float = None,
+    mag_max: float = None,
+):
+    """
+    Build WHERE clause and parameters for asteroid queries.
+
+    Returns (where_suffix, params) where where_suffix is '' or ' WHERE ...'.
+    """
+    where_clauses = []
+    params = []
+
+    if designation:
+        where_clauses.append("designation ILIKE %s")
+        params.append(f"%{designation}%")
+
+    if number is not None:
+        where_clauses.append("number = %s")
+        params.append(number)
+
+    if numbered is not None:
+        where_clauses.append("number IS NOT NULL" if numbered else "number IS NULL")
+
+    if mag_min is not None:
+        where_clauses.append("absolute_magnitude >= %s")
+        params.append(mag_min)
+
+    if mag_max is not None:
+        where_clauses.append("absolute_magnitude <= %s")
+        params.append(mag_max)
+
+    if where_clauses:
+        return " WHERE " + " AND ".join(where_clauses), params
+    return "", []
+
+
+def asteroids_count(
+    conn,
+    designation: str = None,
+    number: int = None,
+    numbered: bool = None,
+    mag_min: float = None,
+    mag_max: float = None,
+) -> int:
+    """Return count of asteroids matching the given filters."""
+    where, params = asteroids_build_where(
+        designation=designation, number=number, numbered=numbered,
+        mag_min=mag_min, mag_max=mag_max,
+    )
+    query = "SELECT COUNT(*) FROM asteroids" + where
+    return run_query(conn, query, tuple(params) if params else None)[0][0]
+
+
+def asteroids_search(
+    conn,
+    designation: str = None,
+    number: int = None,
+    numbered: bool = None,
+    mag_min: float = None,
+    mag_max: float = None,
+    sort_by: str = "number",
+    sort_order: str = "asc",
+    limit: int = None,
+    offset: int = None,
+) -> List:
+    """Search asteroids with optional filters, sorting, and paging."""
+    if sort_by not in ASTEROID_SORT_FIELDS:
+        sort_by = "number"
+    if sort_order not in ("asc", "desc"):
+        sort_order = "asc"
+
+    where, params = asteroids_build_where(
+        designation=designation, number=number, numbered=numbered,
+        mag_min=mag_min, mag_max=mag_max,
+    )
+
+    query = _ASTEROID_SELECT + where
+    query += f" ORDER BY {sort_by} {sort_order.upper()} NULLS LAST, id ASC"
+    if limit is not None:
+        query += " LIMIT %s"
+        params.append(limit)
+    if offset is not None:
+        query += " OFFSET %s"
+        params.append(offset)
+
+    return run_query(conn, query, tuple(params) if params else None)
+
+
+def asteroid_get_by_id(conn, asteroid_id: int):
+    """Return a single asteroid row by its primary key, or None if not found."""
+    rows = run_query(conn, _ASTEROID_SELECT + " WHERE id = %s", (asteroid_id,))
+    return rows[0] if rows else None
+
+
 def tasks_radius_get(conn, ra: float, decl: float, radius: float, filter: str = "", order: str = "") -> List:
     """
     Returns frames (completed tasks) that are close (within radius degrees) to

--- a/hevelius/db.py
+++ b/hevelius/db.py
@@ -472,12 +472,12 @@ def catalog_objects_search(
 
 
 ASTEROID_SORT_FIELDS = {
-    "number", "designation", "absolute_magnitude", "semimajor_axis",
+    "number", "designation", "name", "absolute_magnitude", "semimajor_axis",
     "eccentricity", "inclination", "mean_motion", "epoch",
 }
 
 _ASTEROID_SELECT = """
-    SELECT id, number, designation, epoch, mean_anomaly, perihelion_arg,
+    SELECT id, number, designation, name, epoch, mean_anomaly, perihelion_arg,
            ascending_node, inclination, eccentricity, mean_motion,
            semimajor_axis, absolute_magnitude, slope_parameter
     FROM asteroids
@@ -486,6 +486,7 @@ _ASTEROID_SELECT = """
 
 def asteroids_build_where(
     designation: str = None,
+    name: str = None,
     number: int = None,
     numbered: bool = None,
     mag_min: float = None,
@@ -510,6 +511,10 @@ def asteroids_build_where(
     if designation:
         where_clauses.append("designation ILIKE %s")
         params.append(f"%{designation}%")
+
+    if name:
+        where_clauses.append("name ILIKE %s")
+        params.append(f"%{name}%")
 
     if number is not None:
         where_clauses.append("number = %s")
@@ -552,6 +557,7 @@ def asteroids_build_where(
 def asteroids_count(
     conn,
     designation: str = None,
+    name: str = None,
     number: int = None,
     numbered: bool = None,
     mag_min: float = None,
@@ -567,7 +573,7 @@ def asteroids_count(
     approximate counts, or requiring a filter if this becomes a bottleneck.
     """
     where, params = asteroids_build_where(
-        designation=designation, number=number, numbered=numbered,
+        designation=designation, name=name, number=number, numbered=numbered,
         mag_min=mag_min, mag_max=mag_max, tag_names=tag_names, tags_mode=tags_mode,
     )
     query = "SELECT COUNT(*) FROM asteroids" + where
@@ -577,6 +583,7 @@ def asteroids_count(
 def asteroids_search(
     conn,
     designation: str = None,
+    name: str = None,
     number: int = None,
     numbered: bool = None,
     mag_min: float = None,
@@ -595,7 +602,7 @@ def asteroids_search(
         sort_order = "asc"
 
     where, params = asteroids_build_where(
-        designation=designation, number=number, numbered=numbered,
+        designation=designation, name=name, number=number, numbered=numbered,
         mag_min=mag_min, mag_max=mag_max, tag_names=tag_names, tags_mode=tags_mode,
     )
 
@@ -615,6 +622,55 @@ def asteroid_get_by_id(conn, asteroid_id: int):
     """Return a single asteroid row by its primary key, or None if not found."""
     rows = run_query(conn, _ASTEROID_SELECT + " WHERE id = %s", (asteroid_id,))
     return rows[0] if rows else None
+
+
+def asteroids_find_by_query(conn, query: str, limit: int = 20) -> List:
+    """
+    Resolve a user query (name, designation, or MPC number) to asteroid rows.
+
+    Preference order:
+      1. Exact MPC number (when query is an integer)
+      2. Exact case-insensitive proper name
+      3. Exact case-insensitive packed designation
+      4. Partial name / designation matches (ILIKE)
+    """
+    q = (query or "").strip()
+    if not q:
+        return []
+
+    if q.isdigit():
+        rows = run_query(
+            conn,
+            _ASTEROID_SELECT + " WHERE number = %s ORDER BY id ASC LIMIT %s",
+            (int(q), limit),
+        )
+        if rows:
+            return rows
+
+    exact_name = run_query(
+        conn,
+        _ASTEROID_SELECT + " WHERE lower(name) = lower(%s) ORDER BY number NULLS LAST, id ASC LIMIT %s",
+        (q, limit),
+    )
+    if exact_name:
+        return exact_name
+
+    exact_desig = run_query(
+        conn,
+        _ASTEROID_SELECT
+        + " WHERE lower(designation) = lower(%s) ORDER BY number NULLS LAST, id ASC LIMIT %s",
+        (q, limit),
+    )
+    if exact_desig:
+        return exact_desig
+
+    return run_query(
+        conn,
+        _ASTEROID_SELECT
+        + " WHERE name ILIKE %s OR designation ILIKE %s"
+        + " ORDER BY number NULLS LAST, id ASC LIMIT %s",
+        (f"%{q}%", f"%{q}%", limit),
+    )
 
 
 def asteroid_tags_for_asteroids(conn, asteroid_ids: List[int]) -> dict:

--- a/hevelius/db.py
+++ b/hevelius/db.py
@@ -490,11 +490,19 @@ def asteroids_build_where(
     numbered: bool = None,
     mag_min: float = None,
     mag_max: float = None,
+    tag_names: List[str] = None,
+    tags_mode: str = "any",
 ):
     """
     Build WHERE clause and parameters for asteroid queries.
 
     Returns (where_suffix, params) where where_suffix is '' or ' WHERE ...'.
+
+    tag_names/tags_mode filter by tag membership: "any" (default) matches
+    asteroids carrying at least one of the given tags, "all" requires every
+    given tag to be present. Both forms use the asteroid_tag_map(tag_id)
+    index via a correlated subquery keyed on asteroid_id, so filtering stays
+    cheap even with a large asteroid catalogue.
     """
     where_clauses = []
     params = []
@@ -518,6 +526,24 @@ def asteroids_build_where(
         where_clauses.append("absolute_magnitude <= %s")
         params.append(mag_max)
 
+    if tag_names:
+        distinct_names = list(dict.fromkeys(tag_names))
+        if tags_mode == "all":
+            where_clauses.append(
+                "(SELECT COUNT(DISTINCT m.tag_id) FROM asteroid_tag_map m "
+                "JOIN asteroid_tags t ON t.tag_id = m.tag_id "
+                "WHERE m.asteroid_id = asteroids.id AND t.name = ANY(%s)) = %s"
+            )
+            params.append(distinct_names)
+            params.append(len(distinct_names))
+        else:
+            where_clauses.append(
+                "EXISTS (SELECT 1 FROM asteroid_tag_map m "
+                "JOIN asteroid_tags t ON t.tag_id = m.tag_id "
+                "WHERE m.asteroid_id = asteroids.id AND t.name = ANY(%s))"
+            )
+            params.append(distinct_names)
+
     if where_clauses:
         return " WHERE " + " AND ".join(where_clauses), params
     return "", []
@@ -530,11 +556,13 @@ def asteroids_count(
     numbered: bool = None,
     mag_min: float = None,
     mag_max: float = None,
+    tag_names: List[str] = None,
+    tags_mode: str = "any",
 ) -> int:
     """Return count of asteroids matching the given filters."""
     where, params = asteroids_build_where(
         designation=designation, number=number, numbered=numbered,
-        mag_min=mag_min, mag_max=mag_max,
+        mag_min=mag_min, mag_max=mag_max, tag_names=tag_names, tags_mode=tags_mode,
     )
     query = "SELECT COUNT(*) FROM asteroids" + where
     return run_query(conn, query, tuple(params) if params else None)[0][0]
@@ -547,6 +575,8 @@ def asteroids_search(
     numbered: bool = None,
     mag_min: float = None,
     mag_max: float = None,
+    tag_names: List[str] = None,
+    tags_mode: str = "any",
     sort_by: str = "number",
     sort_order: str = "asc",
     limit: int = None,
@@ -560,7 +590,7 @@ def asteroids_search(
 
     where, params = asteroids_build_where(
         designation=designation, number=number, numbered=numbered,
-        mag_min=mag_min, mag_max=mag_max,
+        mag_min=mag_min, mag_max=mag_max, tag_names=tag_names, tags_mode=tags_mode,
     )
 
     query = _ASTEROID_SELECT + where
@@ -579,6 +609,53 @@ def asteroid_get_by_id(conn, asteroid_id: int):
     """Return a single asteroid row by its primary key, or None if not found."""
     rows = run_query(conn, _ASTEROID_SELECT + " WHERE id = %s", (asteroid_id,))
     return rows[0] if rows else None
+
+
+def asteroid_tags_for_asteroids(conn, asteroid_ids: List[int]) -> dict:
+    """
+    Batch-fetch tags for multiple asteroids in a single query (avoids N+1
+    lookups when building a paginated asteroid list).
+
+    Returns {asteroid_id: [{"tag_id", "name", "description", "color"}, ...]},
+    with every requested id present (empty list if untagged).
+    """
+    result = {aid: [] for aid in asteroid_ids}
+    if not asteroid_ids:
+        return result
+    rows = run_query(
+        conn,
+        """
+        SELECT m.asteroid_id, t.tag_id, t.name, t.description, t.color
+        FROM asteroid_tag_map m
+        JOIN asteroid_tags t ON t.tag_id = m.tag_id
+        WHERE m.asteroid_id = ANY(%s)
+        ORDER BY t.name
+        """,
+        (list(asteroid_ids),),
+    )
+    for asteroid_id, tag_id, name, description, color in rows or []:
+        result[asteroid_id].append({
+            "tag_id": tag_id, "name": name, "description": description, "color": color,
+        })
+    return result
+
+
+def asteroid_tag_attach(conn, asteroid_id: int, tag_id: int) -> None:
+    """Attach a tag to an asteroid; a no-op if already attached."""
+    run_query(
+        conn,
+        "INSERT INTO asteroid_tag_map (asteroid_id, tag_id) VALUES (%s, %s) ON CONFLICT DO NOTHING",
+        (asteroid_id, tag_id),
+    )
+
+
+def asteroid_tag_detach(conn, asteroid_id: int, tag_id: int) -> None:
+    """Detach a tag from an asteroid; a no-op if not attached."""
+    run_query(
+        conn,
+        "DELETE FROM asteroid_tag_map WHERE asteroid_id = %s AND tag_id = %s",
+        (asteroid_id, tag_id),
+    )
 
 
 def tasks_radius_get(conn, ra: float, decl: float, radius: float, filter: str = "", order: str = "") -> List:

--- a/hevelius/db.py
+++ b/hevelius/db.py
@@ -559,7 +559,13 @@ def asteroids_count(
     tag_names: List[str] = None,
     tags_mode: str = "any",
 ) -> int:
-    """Return count of asteroids matching the given filters."""
+    """
+    Return count of asteroids matching the given filters.
+
+    NOTE: An unfiltered COUNT(*) scans the full asteroids table. At MPCORB
+    scale (~1M+ rows) every default list page pays this cost. Consider caching,
+    approximate counts, or requiring a filter if this becomes a bottleneck.
+    """
     where, params = asteroids_build_where(
         designation=designation, number=number, numbered=numbered,
         mag_min=mag_min, mag_max=mag_max, tag_names=tag_names, tags_mode=tags_mode,

--- a/hevelius/db.py
+++ b/hevelius/db.py
@@ -673,6 +673,64 @@ def asteroids_find_by_query(conn, query: str, limit: int = 20) -> List:
     )
 
 
+def telescope_resolve(conn, scope_id: int = None, name: str = None):
+    """
+    Resolve a telescope by scope_id and/or name.
+
+    Returns (scope_id, name, lat, lon, alt) or raises ValueError with a
+    user-facing message when the telescope cannot be uniquely resolved or
+    has no GPS coordinates.
+    """
+    if scope_id is None and not name:
+        raise ValueError("Specify --telescope-id or --telescope.")
+
+    if scope_id is not None:
+        rows = run_query(
+            conn,
+            "SELECT scope_id, name, lat, lon, alt FROM telescopes WHERE scope_id = %s",
+            (scope_id,),
+        )
+        if not rows:
+            raise ValueError(f"Telescope scope_id={scope_id} not found.")
+        row = rows[0]
+        if name and row[1] and row[1].lower() != name.strip().lower():
+            raise ValueError(
+                f"Telescope scope_id={scope_id} is named {row[1]!r}, "
+                f"not {name.strip()!r}."
+            )
+    else:
+        q = name.strip()
+        rows = run_query(
+            conn,
+            "SELECT scope_id, name, lat, lon, alt FROM telescopes "
+            "WHERE lower(name) = lower(%s) ORDER BY scope_id",
+            (q,),
+        )
+        if not rows:
+            rows = run_query(
+                conn,
+                "SELECT scope_id, name, lat, lon, alt FROM telescopes "
+                "WHERE name ILIKE %s ORDER BY scope_id LIMIT 10",
+                (f"%{q}%",),
+            )
+        if not rows:
+            raise ValueError(f"No telescope matching name {q!r}.")
+        if len(rows) > 1:
+            listing = ", ".join(f"{r[0]}:{r[1]}" for r in rows)
+            raise ValueError(
+                f"Multiple telescopes match {q!r} ({listing}). "
+                "Use --telescope-id for an exact match."
+            )
+        row = rows[0]
+
+    sid, tname, lat, lon, alt = row
+    if lat is None or lon is None:
+        raise ValueError(
+            f"Telescope {tname or sid} (scope_id={sid}) has no lat/lon configured."
+        )
+    return sid, tname, float(lat), float(lon), float(alt or 0.0)
+
+
 def asteroid_tags_for_asteroids(conn, asteroid_ids: List[int]) -> dict:
     """
     Batch-fetch tags for multiple asteroids in a single query (avoids N+1

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -872,6 +872,7 @@ class AsteroidSchema(Schema):
     asteroid_id = fields.Integer(required=True, metadata={"description": "Asteroid ID"})
     number = fields.Integer(allow_none=True, metadata={"description": "MPC number (null for unnumbered/provisional objects)"})
     designation = fields.String(required=True, metadata={"description": "Packed MPC designation"})
+    name = fields.String(allow_none=True, metadata={"description": "Proper name (null if unnamed)"})
     epoch = fields.String(metadata={"description": "Epoch in MPC packed format"})
     mean_anomaly = fields.Float(metadata={"description": "Mean anomaly M at epoch (degrees)"})
     perihelion_arg = fields.Float(metadata={"description": "Argument of perihelion omega (degrees)"})
@@ -894,9 +895,9 @@ class AsteroidsListRequestSchema(Schema):
 
     # Sorting parameters
     sort_by = fields.String(missing='number', validate=validate.OneOf(
-        ['number', 'designation', 'absolute_magnitude', 'semimajor_axis',
+        ['number', 'designation', 'name', 'absolute_magnitude', 'semimajor_axis',
          'eccentricity', 'inclination', 'mean_motion', 'epoch'],
-        error="Invalid sort field. Must be one of: number, designation, absolute_magnitude, "
+        error="Invalid sort field. Must be one of: number, designation, name, absolute_magnitude, "
               "semimajor_axis, eccentricity, inclination, mean_motion, epoch"
     ))
     sort_order = fields.String(missing='asc', validate=validate.OneOf(['asc', 'desc']),
@@ -904,6 +905,7 @@ class AsteroidsListRequestSchema(Schema):
 
     # Filtering parameters
     designation = fields.String(metadata={"description": "Filter by designation (partial match)"})
+    name = fields.String(metadata={"description": "Filter by proper name (partial match, case-insensitive)"})
     number = fields.Integer(metadata={"description": "Filter by exact MPC number"})
     numbered = fields.Boolean(metadata={"description": "true: only numbered asteroids; false: only unnumbered/provisional"})
     mag_min = fields.Float(metadata={"description": "Minimum absolute magnitude (H)"})
@@ -3328,13 +3330,14 @@ class ObjectsListResource(MethodView):
 
 
 def _asteroid_row_to_dict(row, tags=None):
-    (asteroid_id, number, designation, epoch, mean_anomaly, perihelion_arg,
+    (asteroid_id, number, designation, name, epoch, mean_anomaly, perihelion_arg,
      ascending_node, inclination, eccentricity, mean_motion, semimajor_axis,
      absolute_magnitude, slope_parameter) = row
     return {
         'asteroid_id': asteroid_id,
         'number': number,
         'designation': designation,
+        'name': name,
         'epoch': epoch,
         'mean_anomaly': mean_anomaly,
         'perihelion_arg': perihelion_arg,
@@ -3392,6 +3395,7 @@ class AsteroidsListResource(MethodView):
         total_count = db.asteroids_count(
             cnx,
             designation=args.get('designation'),
+            name=args.get('name'),
             number=args.get('number'),
             numbered=args.get('numbered'),
             mag_min=args.get('mag_min'),
@@ -3402,6 +3406,7 @@ class AsteroidsListResource(MethodView):
         asteroids_list = db.asteroids_search(
             cnx,
             designation=args.get('designation'),
+            name=args.get('name'),
             number=args.get('number'),
             numbered=args.get('numbered'),
             mag_min=args.get('mag_min'),

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -822,7 +822,14 @@ class AsteroidTagSchema(Schema):
     name = fields.String(required=True, metadata={"description": "Tag name (e.g. amor, neo, pha)"})
     description = fields.String(allow_none=True, metadata={"description": "Tag description"})
     color = fields.String(allow_none=True, metadata={"description": "Display color (e.g. #1976d2)"})
-    asteroid_count = fields.Integer(metadata={"description": "Number of asteroids carrying this tag"})
+    asteroid_count = fields.Integer(
+        metadata={
+            "description": (
+                "Number of asteroids carrying this tag. Present on tag vocabulary "
+                "endpoints; omitted when tags are embedded on asteroid list/detail."
+            )
+        }
+    )
 
 
 class AsteroidTagCreateSchema(Schema):
@@ -833,9 +840,11 @@ class AsteroidTagCreateSchema(Schema):
 
 
 class AsteroidTagUpdateSchema(Schema):
-    name = fields.String(validate=validate.Length(min=1, max=64), load_default=None)
-    description = fields.String(validate=validate.Length(max=256), load_default=None, allow_none=True)
-    color = fields.String(validate=validate.Length(max=16), load_default=None, allow_none=True)
+    # No load_default: absent keys stay absent so PATCH can distinguish
+    # "leave unchanged" from an explicit null clear of nullable fields.
+    name = fields.String(validate=validate.Length(min=1, max=64))
+    description = fields.String(validate=validate.Length(max=256), allow_none=True)
+    color = fields.String(validate=validate.Length(max=16), allow_none=True)
 
 
 class AsteroidTagsListResponseSchema(Schema):
@@ -931,11 +940,21 @@ class AsteroidVisibilityQuerySchema(Schema):
     scope_id = fields.Integer(required=True, metadata={"description": "Telescope to compute visibility from"})
     date = fields.Date(
         load_default=None,
-        metadata={"description": "Evening date (YYYY-MM-DD) whose night to compute; defaults to tonight"}
+        metadata={
+            "description": (
+                "Evening date (YYYY-MM-DD) whose night to compute; defaults to the "
+                "server's local calendar date (not the telescope site's timezone)"
+            )
+        },
     )
     step_minutes = fields.Integer(
         load_default=10, validate=validate.Range(min=1, max=120),
-        metadata={"description": "Sampling interval across the night, in minutes"}
+        metadata={
+            "description": (
+                "Sampling interval across the night, in minutes "
+                "(smaller steps are more CPU-heavy)"
+            )
+        },
     )
 
 
@@ -956,7 +975,12 @@ class AsteroidVisibilityResponseSchema(Schema):
     max_altitude_deg = fields.Float(metadata={"description": "Highest altitude reached during the night"})
     max_altitude_time = fields.String(metadata={"description": "Time of highest altitude (UTC)"})
     apparent_magnitude_at_max = fields.Float(allow_none=True)
-    visible = fields.Boolean(metadata={"description": "Whether the asteroid rises above the horizon during the night"})
+    visible = fields.Boolean(metadata={
+        "description": (
+            "True if max altitude during the night is above the geometric horizon "
+            "(altitude > 0°); no airmass or site horizon mask is applied"
+        )
+    })
     has_magnitude_estimate = fields.Boolean(metadata={"description": "Whether absolute_magnitude (H) was available"})
     msg = fields.String()
 
@@ -3562,7 +3586,7 @@ class AsteroidTagDetailResource(MethodView):
         updates = []
         params = []
         for key in ("name", "description", "color"):
-            if key in tag_data and tag_data[key] is not None:
+            if key in tag_data:
                 updates.append(f"{key} = %s")
                 params.append(tag_data[key])
         if not updates:
@@ -3587,6 +3611,9 @@ class AsteroidTagDetailResource(MethodView):
     def delete(self, tag_id):
         """Delete an asteroid tag (also removes it from any tagged asteroids)."""
         cnx = db.connect()
+        if self._fetch(cnx, tag_id) is None:
+            cnx.close()
+            abort(404, message="Tag not found.")
         db.run_query(cnx, "DELETE FROM asteroid_tags WHERE tag_id = %s", (tag_id,))
         cnx.close()
         return {"status": True, "msg": "Tag deleted"}
@@ -3605,7 +3632,7 @@ class AsteroidTagAttachResource(MethodView):
         tag = db.run_query(cnx, "SELECT tag_id FROM asteroid_tags WHERE tag_id = %s", (tag_id,))
         if not asteroid or not tag:
             cnx.close()
-            return {"status": False, "msg": "Asteroid or tag not found"}
+            abort(404, message="Asteroid or tag not found.")
         db.asteroid_tag_attach(cnx, asteroid_id, tag_id)
         cnx.close()
         return {"status": True, "msg": "Tag added"}

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -814,6 +814,48 @@ class ObjectSearchResponseSchema(Schema):
     objects = fields.List(fields.Nested(ObjectSchema))
 
 
+class AsteroidTagSchema(Schema):
+    tag_id = fields.Integer(required=True, metadata={"description": "Tag ID"})
+    name = fields.String(required=True, metadata={"description": "Tag name (e.g. amor, neo, pha)"})
+    description = fields.String(allow_none=True, metadata={"description": "Tag description"})
+    color = fields.String(allow_none=True, metadata={"description": "Display color (e.g. #1976d2)"})
+    asteroid_count = fields.Integer(metadata={"description": "Number of asteroids carrying this tag"})
+
+
+class AsteroidTagCreateSchema(Schema):
+    name = fields.String(required=True, validate=validate.Length(min=1, max=64),
+                         metadata={"description": "Tag name (e.g. amor, neo, pha)"})
+    description = fields.String(validate=validate.Length(max=256), load_default=None, allow_none=True)
+    color = fields.String(validate=validate.Length(max=16), load_default=None, allow_none=True)
+
+
+class AsteroidTagUpdateSchema(Schema):
+    name = fields.String(validate=validate.Length(min=1, max=64), load_default=None)
+    description = fields.String(validate=validate.Length(max=256), load_default=None, allow_none=True)
+    color = fields.String(validate=validate.Length(max=16), load_default=None, allow_none=True)
+
+
+class AsteroidTagsListResponseSchema(Schema):
+    tags = fields.List(fields.Nested(AsteroidTagSchema))
+
+
+class AsteroidTagCreateResponseSchema(Schema):
+    status = fields.Boolean()
+    tag_id = fields.Integer()
+    tag = fields.Nested(AsteroidTagSchema)
+    msg = fields.String()
+
+
+class AsteroidTagDetailResponseSchema(Schema):
+    status = fields.Boolean()
+    tag = fields.Nested(AsteroidTagSchema)
+    msg = fields.String()
+
+
+class AsteroidTagAttachRequestSchema(Schema):
+    tag_id = fields.Integer(required=True, metadata={"description": "Tag ID to attach"})
+
+
 class AsteroidSchema(Schema):
     asteroid_id = fields.Integer(required=True, metadata={"description": "Asteroid ID"})
     number = fields.Integer(allow_none=True, metadata={"description": "MPC number (null for unnumbered/provisional objects)"})
@@ -828,6 +870,7 @@ class AsteroidSchema(Schema):
     semimajor_axis = fields.Float(metadata={"description": "Semi-major axis a (AU)"})
     absolute_magnitude = fields.Float(allow_none=True, metadata={"description": "Absolute magnitude H"})
     slope_parameter = fields.Float(allow_none=True, metadata={"description": "Phase slope parameter G"})
+    tags = fields.List(fields.Nested(AsteroidTagSchema), metadata={"description": "Tags attached to this asteroid"})
 
 
 class AsteroidsListRequestSchema(Schema):
@@ -853,6 +896,11 @@ class AsteroidsListRequestSchema(Schema):
     numbered = fields.Boolean(metadata={"description": "true: only numbered asteroids; false: only unnumbered/provisional"})
     mag_min = fields.Float(metadata={"description": "Minimum absolute magnitude (H)"})
     mag_max = fields.Float(metadata={"description": "Maximum absolute magnitude (H)"})
+    tags = fields.String(metadata={"description": "Comma-separated tag names to filter by (e.g. 'neo,pha')"})
+    tags_mode = fields.String(
+        missing='any', validate=validate.OneOf(['any', 'all']),
+        metadata={"description": "'any' (default) matches at least one listed tag; 'all' requires every listed tag"}
+    )
 
     @validates_schema
     def validate_mag_range(self, data, **_kwargs):
@@ -3218,7 +3266,7 @@ class ObjectsListResource(MethodView):
         }
 
 
-def _asteroid_row_to_dict(row):
+def _asteroid_row_to_dict(row, tags=None):
     (asteroid_id, number, designation, epoch, mean_anomaly, perihelion_arg,
      ascending_node, inclination, eccentricity, mean_motion, semimajor_axis,
      absolute_magnitude, slope_parameter) = row
@@ -3236,6 +3284,22 @@ def _asteroid_row_to_dict(row):
         'semimajor_axis': semimajor_axis,
         'absolute_magnitude': absolute_magnitude,
         'slope_parameter': slope_parameter,
+        'tags': tags or [],
+    }
+
+
+def _parse_tag_names(raw: str):
+    if not raw:
+        return None
+    names = [n.strip() for n in raw.split(',') if n.strip()]
+    return names or None
+
+
+def _row_to_asteroid_tag(row):
+    tag_id, name, description, color, asteroid_count = row
+    return {
+        'tag_id': tag_id, 'name': name, 'description': description,
+        'color': color, 'asteroid_count': asteroid_count,
     }
 
 
@@ -3260,6 +3324,8 @@ class AsteroidsListResource(MethodView):
         page = args.get('page', 1)
         per_page = args.get('per_page', 100)
         offset = (page - 1) * per_page
+        tag_names = _parse_tag_names(args.get('tags'))
+        tags_mode = args.get('tags_mode', 'any')
 
         cnx = db.connect()
         total_count = db.asteroids_count(
@@ -3269,6 +3335,8 @@ class AsteroidsListResource(MethodView):
             numbered=args.get('numbered'),
             mag_min=args.get('mag_min'),
             mag_max=args.get('mag_max'),
+            tag_names=tag_names,
+            tags_mode=tags_mode,
         )
         asteroids_list = db.asteroids_search(
             cnx,
@@ -3277,11 +3345,14 @@ class AsteroidsListResource(MethodView):
             numbered=args.get('numbered'),
             mag_min=args.get('mag_min'),
             mag_max=args.get('mag_max'),
+            tag_names=tag_names,
+            tags_mode=tags_mode,
             sort_by=args.get('sort_by', 'number'),
             sort_order=args.get('sort_order', 'asc'),
             limit=per_page,
             offset=offset,
         )
+        tags_by_asteroid = db.asteroid_tags_for_asteroids(cnx, [row[0] for row in asteroids_list])
         cnx.close()
 
         logger.info(
@@ -3292,7 +3363,10 @@ class AsteroidsListResource(MethodView):
         total_pages = (total_count + per_page - 1) // per_page if per_page else 0
 
         return {
-            "asteroids": [_asteroid_row_to_dict(row) for row in asteroids_list],
+            "asteroids": [
+                _asteroid_row_to_dict(row, tags=tags_by_asteroid.get(row[0]))
+                for row in asteroids_list
+            ],
             "total": total_count,
             "page": page,
             "per_page": per_page,
@@ -3308,10 +3382,162 @@ class AsteroidDetailResource(MethodView):
         """Get single asteroid by ID"""
         cnx = db.connect()
         row = db.asteroid_get_by_id(cnx, asteroid_id)
+        if row is None:
+            cnx.close()
+            abort(404, message="Asteroid not found.")
+        tags = db.asteroid_tags_for_asteroids(cnx, [asteroid_id]).get(asteroid_id)
+        cnx.close()
+        return {"status": True, "asteroid": _asteroid_row_to_dict(row, tags=tags), "msg": "OK"}
+
+
+@blp.route("/asteroid-tags")
+class AsteroidTagsResource(MethodView):
+    @jwt_required()
+    @blp.response(200, AsteroidTagsListResponseSchema)
+    def get(self):
+        """List all asteroid tags, with the number of asteroids carrying each."""
+        cnx = db.connect()
+        rows = db.run_query(
+            cnx,
+            """SELECT t.tag_id, t.name, t.description, t.color, COUNT(m.asteroid_id)
+               FROM asteroid_tags t
+               LEFT JOIN asteroid_tag_map m ON m.tag_id = t.tag_id
+               GROUP BY t.tag_id
+               ORDER BY t.name""",
+        )
+        cnx.close()
+        return {"tags": [_row_to_asteroid_tag(r) for r in (rows or [])]}
+
+    @jwt_required()
+    @blp.arguments(AsteroidTagCreateSchema)
+    @blp.response(200, AsteroidTagCreateResponseSchema)
+    def post(self, tag_data):
+        """Create a new asteroid tag (e.g. amor, neo, pha, fast rotator)."""
+        cnx = db.connect()
+        try:
+            row = db.run_query(
+                cnx,
+                "INSERT INTO asteroid_tags (name, description, color) VALUES (%s, %s, %s) RETURNING tag_id",
+                (tag_data["name"], tag_data.get("description"), tag_data.get("color")),
+            )
+        except Exception as e:
+            cnx.close()
+            err = str(e).lower()
+            if "unique constraint" in err or "duplicate key" in err:
+                abort(400, message="Tag with this name already exists.")
+            raise
+        tag_id = row if isinstance(row, int) else (row[0] if row else None)
+        cnx.close()
+        if tag_id is None:
+            abort(500, message="Failed to create tag.")
+        return {
+            "status": True,
+            "tag_id": tag_id,
+            "tag": {
+                "tag_id": tag_id, "name": tag_data["name"],
+                "description": tag_data.get("description"), "color": tag_data.get("color"),
+                "asteroid_count": 0,
+            },
+            "msg": "Tag created successfully.",
+        }
+
+
+@blp.route("/asteroid-tags/<int:tag_id>")
+class AsteroidTagDetailResource(MethodView):
+    def _fetch(self, cnx, tag_id):
+        rows = db.run_query(
+            cnx,
+            """SELECT t.tag_id, t.name, t.description, t.color, COUNT(m.asteroid_id)
+               FROM asteroid_tags t
+               LEFT JOIN asteroid_tag_map m ON m.tag_id = t.tag_id
+               WHERE t.tag_id = %s
+               GROUP BY t.tag_id""",
+            (tag_id,),
+        )
+        return rows[0] if rows else None
+
+    @jwt_required()
+    @blp.response(200, AsteroidTagDetailResponseSchema)
+    def get(self, tag_id):
+        """Get a single asteroid tag."""
+        cnx = db.connect()
+        row = self._fetch(cnx, tag_id)
         cnx.close()
         if row is None:
-            abort(404, message="Asteroid not found.")
-        return {"status": True, "asteroid": _asteroid_row_to_dict(row), "msg": "OK"}
+            abort(404, message="Tag not found.")
+        return {"status": True, "tag": _row_to_asteroid_tag(row), "msg": "OK"}
+
+    @jwt_required()
+    @blp.arguments(AsteroidTagUpdateSchema)
+    @blp.response(200, AsteroidTagDetailResponseSchema)
+    def patch(self, tag_data, tag_id):
+        """Edit an asteroid tag (partial update: name, description, color)."""
+        cnx = db.connect()
+        if self._fetch(cnx, tag_id) is None:
+            cnx.close()
+            abort(404, message="Tag not found.")
+        updates = []
+        params = []
+        for key in ("name", "description", "color"):
+            if key in tag_data and tag_data[key] is not None:
+                updates.append(f"{key} = %s")
+                params.append(tag_data[key])
+        if not updates:
+            row = self._fetch(cnx, tag_id)
+            cnx.close()
+            return {"status": True, "tag": _row_to_asteroid_tag(row), "msg": "No changes."}
+        params.append(tag_id)
+        try:
+            db.run_query(cnx, "UPDATE asteroid_tags SET " + ", ".join(updates) + " WHERE tag_id = %s", tuple(params))
+        except Exception as e:
+            cnx.close()
+            err = str(e).lower()
+            if "unique constraint" in err or "duplicate key" in err:
+                abort(400, message="Tag with this name already exists.")
+            raise
+        row = self._fetch(cnx, tag_id)
+        cnx.close()
+        return {"status": True, "tag": _row_to_asteroid_tag(row), "msg": "Tag updated."}
+
+    @jwt_required()
+    @blp.response(200, StatusMsgSchema)
+    def delete(self, tag_id):
+        """Delete an asteroid tag (also removes it from any tagged asteroids)."""
+        cnx = db.connect()
+        db.run_query(cnx, "DELETE FROM asteroid_tags WHERE tag_id = %s", (tag_id,))
+        cnx.close()
+        return {"status": True, "msg": "Tag deleted"}
+
+
+@blp.route("/asteroids/<int:asteroid_id>/tags")
+class AsteroidTagAttachResource(MethodView):
+    @jwt_required()
+    @blp.arguments(AsteroidTagAttachRequestSchema)
+    @blp.response(200, StatusMsgSchema)
+    def post(self, data, asteroid_id):
+        """Attach an existing tag to an asteroid."""
+        tag_id = data["tag_id"]
+        cnx = db.connect()
+        asteroid = db.run_query(cnx, "SELECT id FROM asteroids WHERE id = %s", (asteroid_id,))
+        tag = db.run_query(cnx, "SELECT tag_id FROM asteroid_tags WHERE tag_id = %s", (tag_id,))
+        if not asteroid or not tag:
+            cnx.close()
+            return {"status": False, "msg": "Asteroid or tag not found"}
+        db.asteroid_tag_attach(cnx, asteroid_id, tag_id)
+        cnx.close()
+        return {"status": True, "msg": "Tag added"}
+
+
+@blp.route("/asteroids/<int:asteroid_id>/tags/<int:tag_id>")
+class AsteroidTagDetachResource(MethodView):
+    @jwt_required()
+    @blp.response(200, StatusMsgSchema)
+    def delete(self, asteroid_id, tag_id):
+        """Detach a tag from an asteroid."""
+        cnx = db.connect()
+        db.asteroid_tag_detach(cnx, asteroid_id, tag_id)
+        cnx.close()
+        return {"status": True, "msg": "Tag removed"}
 
 
 # Register blueprint

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -23,7 +23,10 @@ from flask_jwt_extended import JWTManager, create_access_token, jwt_required, ge
 from argon2 import PasswordHasher, Type  # type: ignore[import-not-found]
 from argon2.exceptions import VerifyMismatchError, InvalidHashError  # type: ignore[import-not-found]
 
-from hevelius import cmd_stats, db, config as hevelius_config
+from astropy.coordinates import EarthLocation
+from astropy import units as u
+
+from hevelius import cmd_asteroid, cmd_stats, db, config as hevelius_config
 from hevelius.user_admin_audit import log_user_admin_action
 from hevelius.version import VERSION
 
@@ -921,6 +924,40 @@ class AsteroidsListResponseSchema(Schema):
 class AsteroidDetailResponseSchema(Schema):
     status = fields.Boolean()
     asteroid = fields.Nested(AsteroidSchema)
+    msg = fields.String()
+
+
+class AsteroidVisibilityQuerySchema(Schema):
+    scope_id = fields.Integer(required=True, metadata={"description": "Telescope to compute visibility from"})
+    date = fields.Date(
+        load_default=None,
+        metadata={"description": "Evening date (YYYY-MM-DD) whose night to compute; defaults to tonight"}
+    )
+    step_minutes = fields.Integer(
+        load_default=10, validate=validate.Range(min=1, max=120),
+        metadata={"description": "Sampling interval across the night, in minutes"}
+    )
+
+
+class AsteroidVisibilitySampleSchema(Schema):
+    time = fields.String(metadata={"description": "Sample time (UTC)"})
+    altitude_deg = fields.Float(metadata={"description": "Altitude above the horizon (degrees)"})
+    azimuth_deg = fields.Float(metadata={"description": "Azimuth (degrees, from North through East)"})
+    apparent_magnitude = fields.Float(allow_none=True, metadata={"description": "Estimated apparent magnitude, if H is known"})
+
+
+class AsteroidVisibilityResponseSchema(Schema):
+    status = fields.Boolean()
+    scope_id = fields.Integer()
+    scope_name = fields.String()
+    night_start = fields.String(metadata={"description": "Start of the astronomical night (UTC)"})
+    night_end = fields.String(metadata={"description": "End of the astronomical night (UTC)"})
+    samples = fields.List(fields.Nested(AsteroidVisibilitySampleSchema))
+    max_altitude_deg = fields.Float(metadata={"description": "Highest altitude reached during the night"})
+    max_altitude_time = fields.String(metadata={"description": "Time of highest altitude (UTC)"})
+    apparent_magnitude_at_max = fields.Float(allow_none=True)
+    visible = fields.Boolean(metadata={"description": "Whether the asteroid rises above the horizon during the night"})
+    has_magnitude_estimate = fields.Boolean(metadata={"description": "Whether absolute_magnitude (H) was available"})
     msg = fields.String()
 
 
@@ -3388,6 +3425,52 @@ class AsteroidDetailResource(MethodView):
         tags = db.asteroid_tags_for_asteroids(cnx, [asteroid_id]).get(asteroid_id)
         cnx.close()
         return {"status": True, "asteroid": _asteroid_row_to_dict(row, tags=tags), "msg": "OK"}
+
+
+@blp.route("/asteroids/<int:asteroid_id>/visibility")
+class AsteroidVisibilityResource(MethodView):
+    @jwt_required()
+    @blp.arguments(AsteroidVisibilityQuerySchema, location="query")
+    @blp.response(200, AsteroidVisibilityResponseSchema)
+    def get(self, args, asteroid_id):
+        """
+        Compute altitude/azimuth/magnitude across a night for one asteroid as
+        seen from a telescope's location. Defaults to tonight; pass `date` to
+        check a different night. The orbital mechanics live in
+        hevelius.cmd_asteroid so the same computation can be reused by a
+        future CLI command.
+        """
+        cnx = db.connect()
+        asteroid_row = db.asteroid_get_by_id(cnx, asteroid_id)
+        if asteroid_row is None:
+            cnx.close()
+            abort(404, message="Asteroid not found.")
+
+        scope_id = args["scope_id"]
+        scope_rows = db.run_query(
+            cnx, "SELECT name, lat, lon, alt FROM telescopes WHERE scope_id = %s", (scope_id,)
+        )
+        cnx.close()
+        if not scope_rows:
+            abort(404, message="Telescope not found.")
+        scope_name, lat, lon, alt = scope_rows[0]
+        if lat is None or lon is None:
+            abort(400, message="Telescope has no location (lat/lon) configured.")
+
+        obs_date = args.get("date") or date.today()
+        location = EarthLocation(lat=lat * u.deg, lon=lon * u.deg, height=(alt or 0) * u.m)
+
+        result = cmd_asteroid.compute_asteroid_visibility_curve(
+            asteroid_row[1:], location, obs_date.isoformat(), step_minutes=args.get("step_minutes", 10),
+        )
+
+        return {
+            "status": True,
+            "scope_id": scope_id,
+            "scope_name": scope_name,
+            **result,
+            "msg": "OK",
+        }
 
 
 @blp.route("/asteroid-tags")

--- a/heveliusbackend/app.py
+++ b/heveliusbackend/app.py
@@ -814,6 +814,68 @@ class ObjectSearchResponseSchema(Schema):
     objects = fields.List(fields.Nested(ObjectSchema))
 
 
+class AsteroidSchema(Schema):
+    asteroid_id = fields.Integer(required=True, metadata={"description": "Asteroid ID"})
+    number = fields.Integer(allow_none=True, metadata={"description": "MPC number (null for unnumbered/provisional objects)"})
+    designation = fields.String(required=True, metadata={"description": "Packed MPC designation"})
+    epoch = fields.String(metadata={"description": "Epoch in MPC packed format"})
+    mean_anomaly = fields.Float(metadata={"description": "Mean anomaly M at epoch (degrees)"})
+    perihelion_arg = fields.Float(metadata={"description": "Argument of perihelion omega (degrees)"})
+    ascending_node = fields.Float(metadata={"description": "Longitude of ascending node Omega (degrees)"})
+    inclination = fields.Float(metadata={"description": "Orbital inclination i (degrees)"})
+    eccentricity = fields.Float(metadata={"description": "Eccentricity e"})
+    mean_motion = fields.Float(metadata={"description": "Mean daily motion n (degrees/day)"})
+    semimajor_axis = fields.Float(metadata={"description": "Semi-major axis a (AU)"})
+    absolute_magnitude = fields.Float(allow_none=True, metadata={"description": "Absolute magnitude H"})
+    slope_parameter = fields.Float(allow_none=True, metadata={"description": "Phase slope parameter G"})
+
+
+class AsteroidsListRequestSchema(Schema):
+    # Paging parameters
+    page = fields.Integer(missing=1, validate=validate.Range(min=1),
+                          metadata={"description": "Page number (starting from 1)"})
+    per_page = fields.Integer(missing=100, validate=validate.Range(min=1, max=1000),
+                              metadata={"description": "Number of items per page"})
+
+    # Sorting parameters
+    sort_by = fields.String(missing='number', validate=validate.OneOf(
+        ['number', 'designation', 'absolute_magnitude', 'semimajor_axis',
+         'eccentricity', 'inclination', 'mean_motion', 'epoch'],
+        error="Invalid sort field. Must be one of: number, designation, absolute_magnitude, "
+              "semimajor_axis, eccentricity, inclination, mean_motion, epoch"
+    ))
+    sort_order = fields.String(missing='asc', validate=validate.OneOf(['asc', 'desc']),
+                               metadata={"description": "Sort order (asc or desc)"})
+
+    # Filtering parameters
+    designation = fields.String(metadata={"description": "Filter by designation (partial match)"})
+    number = fields.Integer(metadata={"description": "Filter by exact MPC number"})
+    numbered = fields.Boolean(metadata={"description": "true: only numbered asteroids; false: only unnumbered/provisional"})
+    mag_min = fields.Float(metadata={"description": "Minimum absolute magnitude (H)"})
+    mag_max = fields.Float(metadata={"description": "Maximum absolute magnitude (H)"})
+
+    @validates_schema
+    def validate_mag_range(self, data, **_kwargs):
+        mag_min = data.get('mag_min')
+        mag_max = data.get('mag_max')
+        if mag_min is not None and mag_max is not None and mag_min > mag_max:
+            raise ValidationError('mag_min must be less than or equal to mag_max')
+
+
+class AsteroidsListResponseSchema(Schema):
+    asteroids = fields.List(fields.Nested(AsteroidSchema))
+    total = fields.Integer(required=True, metadata={"description": "Total number of asteroids"})
+    page = fields.Integer(required=True, metadata={"description": "Current page number"})
+    per_page = fields.Integer(required=True, metadata={"description": "Items per page"})
+    pages = fields.Integer(required=True, metadata={"description": "Total number of pages"})
+
+
+class AsteroidDetailResponseSchema(Schema):
+    status = fields.Boolean()
+    asteroid = fields.Nested(AsteroidSchema)
+    msg = fields.String()
+
+
 class PasswordResetCompleteBodySchema(Schema):
     token = fields.String(required=True, metadata={"description": "One-time reset token"})
     new_password = fields.String(
@@ -3154,6 +3216,102 @@ class ObjectsListResource(MethodView):
             "per_page": per_page,
             "pages": total_pages,
         }
+
+
+def _asteroid_row_to_dict(row):
+    (asteroid_id, number, designation, epoch, mean_anomaly, perihelion_arg,
+     ascending_node, inclination, eccentricity, mean_motion, semimajor_axis,
+     absolute_magnitude, slope_parameter) = row
+    return {
+        'asteroid_id': asteroid_id,
+        'number': number,
+        'designation': designation,
+        'epoch': epoch,
+        'mean_anomaly': mean_anomaly,
+        'perihelion_arg': perihelion_arg,
+        'ascending_node': ascending_node,
+        'inclination': inclination,
+        'eccentricity': eccentricity,
+        'mean_motion': mean_motion,
+        'semimajor_axis': semimajor_axis,
+        'absolute_magnitude': absolute_magnitude,
+        'slope_parameter': slope_parameter,
+    }
+
+
+@blp.route("/asteroids")
+class AsteroidsListResource(MethodView):
+    @jwt_required()
+    @blp.arguments(AsteroidsListRequestSchema, location="query")
+    @blp.response(200, AsteroidsListResponseSchema)
+    def get(self, args):
+        """Get list of asteroids with paging, sorting, and filtering"""
+        return self._get_asteroids(args)
+
+    @jwt_required()
+    @blp.arguments(AsteroidsListRequestSchema)
+    @blp.response(200, AsteroidsListResponseSchema)
+    def post(self, args):
+        """Get list of asteroids with paging, sorting, and filtering"""
+        return self._get_asteroids(args)
+
+    def _get_asteroids(self, args):
+        """Helper method to get asteroids based on filters, sorting, and paging"""
+        page = args.get('page', 1)
+        per_page = args.get('per_page', 100)
+        offset = (page - 1) * per_page
+
+        cnx = db.connect()
+        total_count = db.asteroids_count(
+            cnx,
+            designation=args.get('designation'),
+            number=args.get('number'),
+            numbered=args.get('numbered'),
+            mag_min=args.get('mag_min'),
+            mag_max=args.get('mag_max'),
+        )
+        asteroids_list = db.asteroids_search(
+            cnx,
+            designation=args.get('designation'),
+            number=args.get('number'),
+            numbered=args.get('numbered'),
+            mag_min=args.get('mag_min'),
+            mag_max=args.get('mag_max'),
+            sort_by=args.get('sort_by', 'number'),
+            sort_order=args.get('sort_order', 'asc'),
+            limit=per_page,
+            offset=offset,
+        )
+        cnx.close()
+
+        logger.info(
+            "Asteroid list: returned %d entries (page %d, total matching: %d)",
+            len(asteroids_list), page, total_count
+        )
+
+        total_pages = (total_count + per_page - 1) // per_page if per_page else 0
+
+        return {
+            "asteroids": [_asteroid_row_to_dict(row) for row in asteroids_list],
+            "total": total_count,
+            "page": page,
+            "per_page": per_page,
+            "pages": total_pages,
+        }
+
+
+@blp.route("/asteroids/<int:asteroid_id>")
+class AsteroidDetailResource(MethodView):
+    @jwt_required()
+    @blp.response(200, AsteroidDetailResponseSchema)
+    def get(self, asteroid_id):
+        """Get single asteroid by ID"""
+        cnx = db.connect()
+        row = db.asteroid_get_by_id(cnx, asteroid_id)
+        cnx.close()
+        if row is None:
+            abort(404, message="Asteroid not found.")
+        return {"status": True, "asteroid": _asteroid_row_to_dict(row), "msg": "OK"}
 
 
 # Register blueprint

--- a/tests/test_api_asteroid_tags.py
+++ b/tests/test_api_asteroid_tags.py
@@ -1,0 +1,311 @@
+import unittest
+import os
+import json
+from flask_jwt_extended import create_access_token
+from tests.dbtest import use_repository
+from hevelius import db
+from heveliusbackend.app import app
+
+
+class TestAsteroidTags(unittest.TestCase):
+    def setUp(self):
+        """Set up test client before each test"""
+        self.app = app.test_client()
+        self.app.testing = True
+
+        with app.app_context():
+            self.test_token = create_access_token(
+                identity=1,
+                additional_claims={'permissions': 1, 'username': 'test_user'}
+            )
+            self.headers = {
+                'Authorization': f'Bearer {self.test_token}',
+                'Content-Type': 'application/json'
+            }
+
+    def _insert_asteroids(self, cnx):
+        # Note: db.run_query()'s INSERT path only fetchone()s, so a multi-row
+        # RETURNING would silently drop rows; fetch ids back with a SELECT instead.
+        db.run_query(cnx, """
+            INSERT INTO asteroids (
+                number, designation, epoch, mean_anomaly, perihelion_arg,
+                ascending_node, inclination, eccentricity, mean_motion,
+                semimajor_axis, absolute_magnitude, slope_parameter
+            ) VALUES
+            (1, '00001', 'K25A2', 10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77, 3.34, 0.12),
+            (2, '00002', 'K25A2', 20.1, 310.0, 173.1, 34.8, 0.229, 0.213, 2.77, 4.13, 0.11),
+            (3, '00003', 'K25A2', 40.0, 150.0, 103.8, 7.1, 0.089, 0.271, 2.36, 3.20, 0.32)
+        """)
+        rows = db.run_query(cnx, "SELECT id FROM asteroids WHERE designation IN ('00001', '00002', '00003') ORDER BY designation")
+        return [r[0] for r in rows]
+
+    def _create_tag(self, name, description=None, color=None):
+        response = self.app.post(
+            '/api/asteroid-tags',
+            json={'name': name, 'description': description, 'color': color},
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        return json.loads(response.data)['tag_id']
+
+    @use_repository
+    def test_create_list_and_get_tag(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        response = self.app.post(
+            '/api/asteroid-tags',
+            json={'name': 'neo', 'description': 'Near-Earth object', 'color': '#e53935'},
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['status'])
+        tag_id = data['tag_id']
+        self.assertEqual(data['tag']['name'], 'neo')
+        self.assertEqual(data['tag']['asteroid_count'], 0)
+
+        response = self.app.get('/api/asteroid-tags', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        tags = json.loads(response.data)['tags']
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(tags[0]['tag_id'], tag_id)
+        self.assertEqual(tags[0]['description'], 'Near-Earth object')
+
+        response = self.app.get(f'/api/asteroid-tags/{tag_id}', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['status'])
+        self.assertEqual(data['tag']['name'], 'neo')
+
+        response = self.app.get('/api/asteroid-tags/999999', headers=self.headers)
+        self.assertEqual(response.status_code, 404)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_create_duplicate_tag_name_fails(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        self._create_tag('pha')
+        response = self.app.post(
+            '/api/asteroid-tags', json={'name': 'pha'}, headers=self.headers
+        )
+        self.assertEqual(response.status_code, 400)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_create_tag_requires_name(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        response = self.app.post('/api/asteroid-tags', json={}, headers=self.headers)
+        self.assertEqual(response.status_code, 422)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_edit_tag(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        tag_id = self._create_tag('amor', description='Amor family')
+
+        response = self.app.patch(
+            f'/api/asteroid-tags/{tag_id}',
+            json={'description': 'Amor group asteroid', 'color': '#3949ab'},
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['tag']['description'], 'Amor group asteroid')
+        self.assertEqual(data['tag']['color'], '#3949ab')
+        self.assertEqual(data['tag']['name'], 'amor')
+
+        # Renaming to a name already used by another tag fails
+        self._create_tag('apollo')
+        response = self.app.patch(
+            f'/api/asteroid-tags/{tag_id}', json={'name': 'apollo'}, headers=self.headers
+        )
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.patch(
+            '/api/asteroid-tags/999999', json={'name': 'x'}, headers=self.headers
+        )
+        self.assertEqual(response.status_code, 404)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_delete_tag_removes_it_from_asteroids(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_ids = self._insert_asteroids(cnx)
+        cnx.close()
+        tag_id = self._create_tag('fast rotator')
+
+        self.app.post(
+            f'/api/asteroids/{asteroid_ids[0]}/tags', json={'tag_id': tag_id}, headers=self.headers
+        )
+        response = self.app.get(f'/api/asteroids/{asteroid_ids[0]}', headers=self.headers)
+        self.assertEqual(len(json.loads(response.data)['asteroid']['tags']), 1)
+
+        response = self.app.delete(f'/api/asteroid-tags/{tag_id}', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get('/api/asteroid-tags', headers=self.headers)
+        self.assertEqual(json.loads(response.data)['tags'], [])
+
+        response = self.app.get(f'/api/asteroids/{asteroid_ids[0]}', headers=self.headers)
+        self.assertEqual(json.loads(response.data)['asteroid']['tags'], [])
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_attach_and_detach_tag(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_ids = self._insert_asteroids(cnx)
+        cnx.close()
+        tag_id = self._create_tag('neo')
+
+        response = self.app.post(
+            f'/api/asteroids/{asteroid_ids[0]}/tags', json={'tag_id': tag_id}, headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(json.loads(response.data)['status'])
+
+        # Attaching again is idempotent, no error, no duplicate
+        response = self.app.post(
+            f'/api/asteroids/{asteroid_ids[0]}/tags', json={'tag_id': tag_id}, headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(json.loads(response.data)['status'])
+
+        response = self.app.get(f'/api/asteroids/{asteroid_ids[0]}', headers=self.headers)
+        tags = json.loads(response.data)['asteroid']['tags']
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(tags[0]['name'], 'neo')
+
+        response = self.app.get('/api/asteroid-tags', headers=self.headers)
+        tags_list = json.loads(response.data)['tags']
+        self.assertEqual(tags_list[0]['asteroid_count'], 1)
+
+        response = self.app.delete(
+            f'/api/asteroids/{asteroid_ids[0]}/tags/{tag_id}', headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get(f'/api/asteroids/{asteroid_ids[0]}', headers=self.headers)
+        self.assertEqual(json.loads(response.data)['asteroid']['tags'], [])
+
+        # Detaching a tag that isn't attached is a harmless no-op
+        response = self.app.delete(
+            f'/api/asteroids/{asteroid_ids[0]}/tags/{tag_id}', headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_attach_unknown_asteroid_or_tag(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_ids = self._insert_asteroids(cnx)
+        cnx.close()
+        tag_id = self._create_tag('neo')
+
+        response = self.app.post(
+            '/api/asteroids/999999/tags', json={'tag_id': tag_id}, headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(json.loads(response.data)['status'])
+
+        response = self.app.post(
+            f'/api/asteroids/{asteroid_ids[0]}/tags', json={'tag_id': 999999}, headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(json.loads(response.data)['status'])
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_asteroids_list_includes_tags(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_ids = self._insert_asteroids(cnx)
+        cnx.close()
+        tag_id = self._create_tag('neo')
+        self.app.post(f'/api/asteroids/{asteroid_ids[0]}/tags', json={'tag_id': tag_id}, headers=self.headers)
+
+        response = self.app.get('/api/asteroids', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        asteroids = {a['asteroid_id']: a for a in json.loads(response.data)['asteroids']}
+        self.assertEqual(len(asteroids[asteroid_ids[0]]['tags']), 1)
+        self.assertEqual(asteroids[asteroid_ids[0]]['tags'][0]['name'], 'neo')
+        self.assertEqual(asteroids[asteroid_ids[1]]['tags'], [])
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_filter_asteroids_by_tags_any_and_all(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_ids = self._insert_asteroids(cnx)
+        cnx.close()
+        neo_id = self._create_tag('neo')
+        pha_id = self._create_tag('pha')
+
+        # asteroid_ids[0]: neo only
+        self.app.post(f'/api/asteroids/{asteroid_ids[0]}/tags', json={'tag_id': neo_id}, headers=self.headers)
+        # asteroid_ids[1]: pha only
+        self.app.post(f'/api/asteroids/{asteroid_ids[1]}/tags', json={'tag_id': pha_id}, headers=self.headers)
+        # asteroid_ids[2]: both neo and pha
+        self.app.post(f'/api/asteroids/{asteroid_ids[2]}/tags', json={'tag_id': neo_id}, headers=self.headers)
+        self.app.post(f'/api/asteroids/{asteroid_ids[2]}/tags', json={'tag_id': pha_id}, headers=self.headers)
+
+        # Default mode ("any"): asteroids with neo OR pha -> all three
+        response = self.app.get('/api/asteroids?tags=neo,pha', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 3)
+
+        # Filter by a single tag
+        response = self.app.get('/api/asteroids?tags=neo', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 2)
+        ids = {a['asteroid_id'] for a in data['asteroids']}
+        self.assertEqual(ids, {asteroid_ids[0], asteroid_ids[2]})
+
+        # "all" mode: must have both neo AND pha -> only asteroid_ids[2]
+        response = self.app.get('/api/asteroids?tags=neo,pha&tags_mode=all', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 1)
+        self.assertEqual(data['asteroids'][0]['asteroid_id'], asteroid_ids[2])
+
+        # Unknown tag name matches nothing
+        response = self.app.get('/api/asteroids?tags=doesnotexist', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 0)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    def test_unauthorized_access(self):
+        response = self.app.get('/api/asteroid-tags')
+        self.assertEqual(response.status_code, 401)
+
+        response = self.app.post('/api/asteroid-tags', json={'name': 'x'})
+        self.assertEqual(response.status_code, 401)
+
+        response = self.app.post('/api/asteroids/1/tags', json={'tag_id': 1})
+        self.assertEqual(response.status_code, 401)
+
+        response = self.app.delete('/api/asteroids/1/tags/1')
+        self.assertEqual(response.status_code, 401)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_api_asteroid_tags.py
+++ b/tests/test_api_asteroid_tags.py
@@ -120,6 +120,18 @@ class TestAsteroidTags(unittest.TestCase):
         self.assertEqual(data['tag']['color'], '#3949ab')
         self.assertEqual(data['tag']['name'], 'amor')
 
+        # Explicit null clears nullable fields
+        response = self.app.patch(
+            f'/api/asteroid-tags/{tag_id}',
+            json={'description': None, 'color': None},
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIsNone(data['tag']['description'])
+        self.assertIsNone(data['tag']['color'])
+        self.assertEqual(data['tag']['name'], 'amor')
+
         # Renaming to a name already used by another tag fails
         self._create_tag('apollo')
         response = self.app.patch(
@@ -157,6 +169,9 @@ class TestAsteroidTags(unittest.TestCase):
 
         response = self.app.get(f'/api/asteroids/{asteroid_ids[0]}', headers=self.headers)
         self.assertEqual(json.loads(response.data)['asteroid']['tags'], [])
+
+        response = self.app.delete('/api/asteroid-tags/999999', headers=self.headers)
+        self.assertEqual(response.status_code, 404)
 
         os.environ.pop('HEVELIUS_DB_NAME')
 
@@ -219,14 +234,12 @@ class TestAsteroidTags(unittest.TestCase):
         response = self.app.post(
             '/api/asteroids/999999/tags', json={'tag_id': tag_id}, headers=self.headers
         )
-        self.assertEqual(response.status_code, 200)
-        self.assertFalse(json.loads(response.data)['status'])
+        self.assertEqual(response.status_code, 404)
 
         response = self.app.post(
             f'/api/asteroids/{asteroid_ids[0]}/tags', json={'tag_id': 999999}, headers=self.headers
         )
-        self.assertEqual(response.status_code, 200)
-        self.assertFalse(json.loads(response.data)['status'])
+        self.assertEqual(response.status_code, 404)
 
         os.environ.pop('HEVELIUS_DB_NAME')
 
@@ -245,6 +258,8 @@ class TestAsteroidTags(unittest.TestCase):
         asteroids = {a['asteroid_id']: a for a in json.loads(response.data)['asteroids']}
         self.assertEqual(len(asteroids[asteroid_ids[0]]['tags']), 1)
         self.assertEqual(asteroids[asteroid_ids[0]]['tags'][0]['name'], 'neo')
+        # Embedded tags omit asteroid_count (vocabulary endpoints include it)
+        self.assertNotIn('asteroid_count', asteroids[asteroid_ids[0]]['tags'][0])
         self.assertEqual(asteroids[asteroid_ids[1]]['tags'], [])
 
         os.environ.pop('HEVELIUS_DB_NAME')

--- a/tests/test_api_asteroid_visibility.py
+++ b/tests/test_api_asteroid_visibility.py
@@ -1,0 +1,178 @@
+import unittest
+import os
+import json
+from flask_jwt_extended import create_access_token
+from tests.dbtest import use_repository
+from hevelius import db
+from heveliusbackend.app import app
+
+
+class TestAsteroidVisibility(unittest.TestCase):
+    def setUp(self):
+        """Set up test client before each test"""
+        self.app = app.test_client()
+        self.app.testing = True
+
+        with app.app_context():
+            self.test_token = create_access_token(
+                identity=1,
+                additional_claims={'permissions': 1, 'username': 'test_user'}
+            )
+            self.headers = {
+                'Authorization': f'Bearer {self.test_token}',
+                'Content-Type': 'application/json'
+            }
+
+    def _insert_asteroid(self, cnx, absolute_magnitude=3.34):
+        db.run_query(cnx, """
+            INSERT INTO asteroids (
+                number, designation, epoch, mean_anomaly, perihelion_arg,
+                ascending_node, inclination, eccentricity, mean_motion,
+                semimajor_axis, absolute_magnitude, slope_parameter
+            ) VALUES
+            (1, '00001', 'K25A2', 10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77, %s, 0.12)
+        """, (absolute_magnitude,))
+        rows = db.run_query(cnx, "SELECT id FROM asteroids WHERE designation = '00001'")
+        return rows[0][0]
+
+    def _insert_scope(self, cnx, scope_id=501, lat=52.2, lon=21.0, alt=100.0, active=True):
+        db.run_query(cnx, """
+            INSERT INTO telescopes (scope_id, name, descr, min_dec, max_dec, focal, aperture,
+                                  lon, lat, alt, sensor_id, active)
+            VALUES (%s, %s, 'Test scope', -90.0, 90.0, 1000.0, 200.0, %s, %s, %s, NULL, %s)
+        """, (scope_id, f'Scope {scope_id}', lon, lat, alt, active))
+        return scope_id
+
+    @use_repository
+    def test_visibility_basic(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_id = self._insert_asteroid(cnx)
+        scope_id = self._insert_scope(cnx)
+        cnx.close()
+
+        response = self.app.get(
+            f'/api/asteroids/{asteroid_id}/visibility?scope_id={scope_id}', headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['status'])
+        self.assertEqual(data['scope_id'], scope_id)
+        self.assertEqual(data['scope_name'], f'Scope {scope_id}')
+        self.assertIn('night_start', data)
+        self.assertIn('night_end', data)
+        self.assertLess(data['night_start'], data['night_end'])
+        self.assertGreater(len(data['samples']), 1)
+        self.assertIn('altitude_deg', data['samples'][0])
+        self.assertIn('azimuth_deg', data['samples'][0])
+        self.assertIsInstance(data['visible'], bool)
+        self.assertTrue(data['has_magnitude_estimate'])
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_visibility_with_explicit_date(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_id = self._insert_asteroid(cnx)
+        scope_id = self._insert_scope(cnx)
+        cnx.close()
+
+        response = self.app.get(
+            f'/api/asteroids/{asteroid_id}/visibility?scope_id={scope_id}&date=2026-01-15',
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['night_start'].startswith('2026-01-15'))
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_visibility_without_magnitude_data(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_id = self._insert_asteroid(cnx, absolute_magnitude=None)
+        scope_id = self._insert_scope(cnx)
+        cnx.close()
+
+        response = self.app.get(
+            f'/api/asteroids/{asteroid_id}/visibility?scope_id={scope_id}', headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertFalse(data['has_magnitude_estimate'])
+        self.assertIsNone(data['apparent_magnitude_at_max'])
+        self.assertTrue(all(s['apparent_magnitude'] is None for s in data['samples']))
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_visibility_missing_scope_id(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_id = self._insert_asteroid(cnx)
+        cnx.close()
+
+        response = self.app.get(f'/api/asteroids/{asteroid_id}/visibility', headers=self.headers)
+        self.assertEqual(response.status_code, 422)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_visibility_asteroid_not_found(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        scope_id = self._insert_scope(cnx)
+        cnx.close()
+
+        response = self.app.get(
+            f'/api/asteroids/999999/visibility?scope_id={scope_id}', headers=self.headers
+        )
+        self.assertEqual(response.status_code, 404)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_visibility_scope_not_found(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_id = self._insert_asteroid(cnx)
+        cnx.close()
+
+        response = self.app.get(
+            f'/api/asteroids/{asteroid_id}/visibility?scope_id=999999', headers=self.headers
+        )
+        self.assertEqual(response.status_code, 404)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_visibility_scope_without_location(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        asteroid_id = self._insert_asteroid(cnx)
+        scope_id = self._insert_scope(cnx, lat=None, lon=None)
+        cnx.close()
+
+        response = self.app.get(
+            f'/api/asteroids/{asteroid_id}/visibility?scope_id={scope_id}', headers=self.headers
+        )
+        self.assertEqual(response.status_code, 400)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    def test_unauthorized_access(self):
+        response = self.app.get('/api/asteroids/1/visibility?scope_id=1')
+        self.assertEqual(response.status_code, 401)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_api_asteroids.py
+++ b/tests/test_api_asteroids.py
@@ -30,13 +30,13 @@ class TestAsteroids(unittest.TestCase):
     def _insert_asteroids(self, cnx):
         db.run_query(cnx, """
             INSERT INTO asteroids (
-                number, designation, epoch, mean_anomaly, perihelion_arg,
+                number, designation, name, epoch, mean_anomaly, perihelion_arg,
                 ascending_node, inclination, eccentricity, mean_motion,
                 semimajor_axis, absolute_magnitude, slope_parameter
             ) VALUES
-            (1, '00001', 'K25A2', 10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77, 3.34, 0.12),
-            (2, '00002', 'K25A2', 20.1, 310.0, 173.1, 34.8, 0.229, 0.213, 2.77, 4.13, 0.11),
-            (NULL, 'K25A00A', 'K25A2', 55.2, 120.0, 200.0, 5.1, 0.15, 0.30, 2.10, 18.5, 0.15)
+            (1, '00001', 'Ceres', 'K25A2', 10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77, 3.34, 0.12),
+            (2, '00002', 'Pallas', 'K25A2', 20.1, 310.0, 173.1, 34.8, 0.229, 0.213, 2.77, 4.13, 0.11),
+            (NULL, 'K25A00A', NULL, 'K25A2', 55.2, 120.0, 200.0, 5.1, 0.15, 0.30, 2.10, 18.5, 0.15)
             RETURNING id
         """)
 
@@ -99,6 +99,14 @@ class TestAsteroids(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual(data['total'], 1)
         self.assertIsNone(data['asteroids'][0]['number'])
+
+        # Filter by proper name (partial, case-insensitive)
+        response = self.app.get('/api/asteroids?name=cere', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 1)
+        self.assertEqual(data['asteroids'][0]['name'], 'Ceres')
+        self.assertEqual(data['asteroids'][0]['number'], 1)
 
         # Filter by numbered=true / numbered=false
         response = self.app.get('/api/asteroids?numbered=true', headers=self.headers)

--- a/tests/test_api_asteroids.py
+++ b/tests/test_api_asteroids.py
@@ -1,0 +1,204 @@
+import unittest
+import os
+import json
+from flask_jwt_extended import create_access_token
+from tests.dbtest import use_repository
+from hevelius import db
+from heveliusbackend.app import app
+
+
+class TestAsteroids(unittest.TestCase):
+    def setUp(self):
+        """Set up test client before each test"""
+        self.app = app.test_client()
+        self.app.testing = True
+
+        # Create a test JWT token
+        with app.app_context():
+            self.test_token = create_access_token(
+                identity=1,  # user_id=1
+                additional_claims={
+                    'permissions': 1,
+                    'username': 'test_user'
+                }
+            )
+            self.headers = {
+                'Authorization': f'Bearer {self.test_token}',
+                'Content-Type': 'application/json'
+            }
+
+    def _insert_asteroids(self, cnx):
+        db.run_query(cnx, """
+            INSERT INTO asteroids (
+                number, designation, epoch, mean_anomaly, perihelion_arg,
+                ascending_node, inclination, eccentricity, mean_motion,
+                semimajor_axis, absolute_magnitude, slope_parameter
+            ) VALUES
+            (1, '00001', 'K25A2', 10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77, 3.34, 0.12),
+            (2, '00002', 'K25A2', 20.1, 310.0, 173.1, 34.8, 0.229, 0.213, 2.77, 4.13, 0.11),
+            (NULL, 'K25A00A', 'K25A2', 55.2, 120.0, 200.0, 5.1, 0.15, 0.30, 2.10, 18.5, 0.15)
+            RETURNING id
+        """)
+
+    @use_repository
+    def test_asteroids_list(self, config):
+        """Test asteroids list endpoint: basic listing, paging, sorting, filtering"""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        self._insert_asteroids(cnx)
+        cnx.close()
+
+        # Basic list
+        response = self.app.get('/api/asteroids', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIn('asteroids', data)
+        self.assertIn('total', data)
+        self.assertIn('page', data)
+        self.assertIn('per_page', data)
+        self.assertIn('pages', data)
+        self.assertEqual(data['total'], 3)
+        self.assertEqual(len(data['asteroids']), 3)
+
+        # Default sort is by number ascending, with NULLs (unnumbered) last
+        numbers = [a['number'] for a in data['asteroids']]
+        self.assertEqual(numbers, [1, 2, None])
+
+        # Paging
+        response = self.app.get('/api/asteroids?page=1&per_page=2', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(len(data['asteroids']), 2)
+        self.assertEqual(data['pages'], 2)
+
+        response = self.app.get('/api/asteroids?page=2&per_page=2', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(len(data['asteroids']), 1)
+
+        # Sorting by absolute_magnitude descending
+        response = self.app.get(
+            '/api/asteroids?sort_by=absolute_magnitude&sort_order=desc', headers=self.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        mags = [a['absolute_magnitude'] for a in data['asteroids']]
+        self.assertEqual(mags, sorted(mags, reverse=True))
+
+        # Filter by exact number
+        response = self.app.get('/api/asteroids?number=2', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 1)
+        self.assertEqual(data['asteroids'][0]['designation'], '00002')
+
+        # Filter by designation (partial match)
+        response = self.app.get('/api/asteroids?designation=K25A00A', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 1)
+        self.assertIsNone(data['asteroids'][0]['number'])
+
+        # Filter by numbered=true / numbered=false
+        response = self.app.get('/api/asteroids?numbered=true', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 2)
+        self.assertTrue(all(a['number'] is not None for a in data['asteroids']))
+
+        response = self.app.get('/api/asteroids?numbered=false', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 1)
+        self.assertIsNone(data['asteroids'][0]['number'])
+
+        # Filter by magnitude range
+        response = self.app.get('/api/asteroids?mag_min=4.0&mag_max=10.0', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 1)
+        self.assertEqual(data['asteroids'][0]['designation'], '00002')
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_asteroids_list_post(self, config):
+        """Test asteroids list endpoint with POST method"""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        self._insert_asteroids(cnx)
+        cnx.close()
+
+        response = self.app.post(
+            '/api/asteroids',
+            json={'numbered': True, 'sort_by': 'number', 'sort_order': 'desc'},
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 2)
+        self.assertEqual([a['number'] for a in data['asteroids']], [2, 1])
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_asteroid_detail(self, config):
+        """Test single asteroid detail endpoint"""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        cnx = db.connect()
+        self._insert_asteroids(cnx)
+        rows = db.run_query(cnx, "SELECT id FROM asteroids WHERE designation = '00001'")
+        asteroid_id = rows[0][0]
+        cnx.close()
+
+        response = self.app.get(f'/api/asteroids/{asteroid_id}', headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['status'])
+        self.assertEqual(data['asteroid']['designation'], '00001')
+        self.assertEqual(data['asteroid']['number'], 1)
+        self.assertEqual(data['asteroid']['asteroid_id'], asteroid_id)
+
+        # Not found
+        response = self.app.get('/api/asteroids/999999', headers=self.headers)
+        self.assertEqual(response.status_code, 404)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    def test_unauthorized_access(self):
+        """Test unauthorized access to endpoints"""
+        response = self.app.get('/api/asteroids')
+        self.assertEqual(response.status_code, 401)
+
+        response = self.app.get('/api/asteroids/1')
+        self.assertEqual(response.status_code, 401)
+
+    @use_repository
+    def test_invalid_parameters(self, config):
+        """Test endpoints with invalid parameters"""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+
+        response = self.app.get('/api/asteroids?sort_by=invalid', headers=self.headers)
+        self.assertEqual(response.status_code, 422)
+
+        response = self.app.get('/api/asteroids?sort_order=invalid', headers=self.headers)
+        self.assertEqual(response.status_code, 422)
+
+        response = self.app.get('/api/asteroids?page=0', headers=self.headers)
+        self.assertEqual(response.status_code, 422)
+
+        response = self.app.get('/api/asteroids?per_page=0', headers=self.headers)
+        self.assertEqual(response.status_code, 422)
+
+        # mag_min greater than mag_max
+        response = self.app.get('/api/asteroids?mag_min=10&mag_max=5', headers=self.headers)
+        self.assertEqual(response.status_code, 422)
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_api_asteroids.py
+++ b/tests/test_api_asteroids.py
@@ -161,6 +161,7 @@ class TestAsteroids(unittest.TestCase):
         self.assertEqual(data['asteroid']['designation'], '00001')
         self.assertEqual(data['asteroid']['number'], 1)
         self.assertEqual(data['asteroid']['asteroid_id'], asteroid_id)
+        self.assertEqual(data['asteroid']['tags'], [])
 
         # Not found
         response = self.app.get('/api/asteroids/999999', headers=self.headers)

--- a/tests/test_asteroid_list.py
+++ b/tests/test_asteroid_list.py
@@ -1,0 +1,84 @@
+"""Tests for `hevelius asteroid list`."""
+
+import io
+import os
+import unittest
+from argparse import Namespace
+from contextlib import redirect_stdout
+
+from tests.dbtest import use_repository
+from hevelius import db, cmd_asteroid
+
+
+class TestAsteroidsList(unittest.TestCase):
+    def _insert(self, cnx):
+        db.run_query(cnx, """
+            INSERT INTO asteroids (
+                number, designation, name, epoch, mean_anomaly, perihelion_arg,
+                ascending_node, inclination, eccentricity, mean_motion,
+                semimajor_axis, absolute_magnitude, slope_parameter
+            ) VALUES
+            (1, '00001', 'Ceres', 'K25A2', 10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77, 3.34, 0.12),
+            (2, '00002', 'Pallas', 'K25A2', 20.1, 310.0, 173.1, 34.8, 0.229, 0.213, 2.77, 4.13, 0.11),
+            (4, '00004', 'Vesta', 'K25A2', 40.0, 150.0, 103.8, 7.1, 0.089, 0.271, 2.36, 3.20, 0.32),
+            (NULL, 'K25A00A', NULL, 'K25A2', 55.2, 120.0, 200.0, 5.1, 0.15, 0.30, 2.10, 18.5, 0.15)
+        """)
+
+    def _args(self, **kwargs):
+        defaults = dict(
+            limit=100, offset=0, sort_by='number', sort_order='asc',
+            name=None, designation=None, number=None,
+            numbered=None, unnumbered=False,
+            mag_min=None, mag_max=None, tags=None, tags_mode='any',
+            no_color=True,
+        )
+        defaults.update(kwargs)
+        return Namespace(**defaults)
+
+    @use_repository
+    def test_list_defaults_and_filters(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        self._insert(cnx)
+        cnx.close()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_list(self._args())
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn('showing 1–4 of 4', out)
+        self.assertIn('Ceres', out)
+        self.assertIn('Pallas', out)
+        # Default sort by number ascending: Ceres before Vesta; provisional last
+        self.assertLess(out.index('Ceres'), out.index('Vesta'))
+        self.assertLess(out.index('Vesta'), out.index('K25A00A'))
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_list(self._args(name='ves', limit=10))
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn('Vesta', out)
+        self.assertNotIn('Ceres', out)
+        self.assertIn('of 1', out)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_list(self._args(numbered=True))
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn('of 3', out)
+        self.assertNotIn('K25A00A', out)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_list(
+                self._args(sort_by='absolute_magnitude', sort_order='desc', limit=2)
+            )
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn('showing 1–2 of 4', out)
+        self.assertIn('more', out)
+
+        os.environ.pop('HEVELIUS_DB_NAME')

--- a/tests/test_asteroid_show.py
+++ b/tests/test_asteroid_show.py
@@ -99,3 +99,139 @@ class TestExtractName(unittest.TestCase):
         self.assertIsNone(cmd_asteroid._extract_name_from_readable('1960 SB1'))
         self.assertIsNone(cmd_asteroid._extract_name_from_readable('(123456)'))
         self.assertIsNone(cmd_asteroid._extract_name_from_readable(''))
+
+
+class TestAltitudeChart(unittest.TestCase):
+    def test_render_altitude_chart_has_horizon_and_times(self):
+        samples = [
+            {"time": "2026-07-22 20:00:00.000", "altitude_deg": -10.0,
+             "azimuth_deg": 90.0, "apparent_magnitude": 8.0, "moon_up": False},
+            {"time": "2026-07-22 22:00:00.000", "altitude_deg": 20.0,
+             "azimuth_deg": 120.0, "apparent_magnitude": 7.5, "moon_up": True},
+            {"time": "2026-07-23 00:00:00.000", "altitude_deg": 45.0,
+             "azimuth_deg": 180.0, "apparent_magnitude": 7.0, "moon_up": True},
+            {"time": "2026-07-23 02:00:00.000", "altitude_deg": 15.0,
+             "azimuth_deg": 240.0, "apparent_magnitude": 7.4, "moon_up": False},
+            {"time": "2026-07-23 04:00:00.000", "altitude_deg": -5.0,
+             "azimuth_deg": 270.0, "apparent_magnitude": 8.1, "moon_up": False},
+        ]
+        lines = cmd_asteroid.render_altitude_chart(samples, width=40, height=10, color=False)
+        joined = "\n".join(lines)
+        self.assertIn("horizon", joined)
+        self.assertIn("●", joined)
+        self.assertIn("20:00", joined)
+        self.assertIn("04:00", joined)
+
+        colored = "\n".join(
+            cmd_asteroid.render_altitude_chart(samples, width=40, height=10, color=True)
+        )
+        self.assertIn("\033[33m", colored)  # yellow for moon-up columns
+        self.assertIn("asteroid + moon up", colored)
+
+
+class TestNightWindow(unittest.TestCase):
+    def test_summer_night_is_evening_to_morning_not_daytime(self):
+        from astropy.coordinates import EarthLocation
+        from astropy.time import Time
+        from astropy import units as u
+
+        loc = EarthLocation(lat=52.2 * u.deg, lon=21.0 * u.deg, height=100 * u.m)
+        start, end = cmd_asteroid._get_night_times(loc, Time("2026-07-22 00:00:00"))
+        self.assertLess(start, end)
+        # Must cross midnight and start in the evening (not the old 06:00–18:00 fallback)
+        self.assertNotEqual(start.iso[:10], end.iso[:10])
+        self.assertGreaterEqual(int(start.iso[11:13]), 15)
+        self.assertLess(int(end.iso[11:13]), 8)
+
+
+class TestTelescopeResolveAndShowVisibility(unittest.TestCase):
+    def _insert_asteroid(self, cnx):
+        db.run_query(cnx, """
+            INSERT INTO asteroids (
+                number, designation, name, epoch, mean_anomaly, perihelion_arg,
+                ascending_node, inclination, eccentricity, mean_motion,
+                semimajor_axis, absolute_magnitude, slope_parameter
+            ) VALUES
+            (4, '00004', 'Vesta', 'K25A2', 10.5, 73.6, 80.3, 7.1, 0.089, 0.271, 2.36, 3.20, 0.32)
+        """)
+
+    def _insert_scope(self, cnx, scope_id=3, name='hakos-e180', lat=-23.2, lon=16.3, alt=1800.0):
+        db.run_query(cnx, """
+            INSERT INTO telescopes (scope_id, name, descr, min_dec, max_dec, focal, aperture,
+                                  lon, lat, alt, sensor_id, active)
+            VALUES (%s, %s, 'Test', -90.0, 90.0, 1800.0, 180.0, %s, %s, %s, NULL, true)
+        """, (scope_id, name, lon, lat, alt))
+
+    @use_repository
+    def test_telescope_resolve_by_id_and_name(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        self._insert_scope(cnx)
+
+        by_id = db.telescope_resolve(cnx, scope_id=3)
+        self.assertEqual(by_id[0], 3)
+        self.assertEqual(by_id[1], 'hakos-e180')
+
+        by_name = db.telescope_resolve(cnx, name='hakos-e180')
+        self.assertEqual(by_name[0], 3)
+
+        by_partial = db.telescope_resolve(cnx, name='hakos')
+        self.assertEqual(by_partial[0], 3)
+
+        with self.assertRaises(ValueError):
+            db.telescope_resolve(cnx, scope_id=999)
+
+        with self.assertRaises(ValueError):
+            db.telescope_resolve(cnx, name='missing-scope')
+
+        cnx.close()
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_cli_show_with_telescope_prints_chart(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        self._insert_asteroid(cnx)
+        self._insert_scope(cnx)
+        cnx.close()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_show(Namespace(
+                query='Vesta',
+                limit=20,
+                no_color=True,
+                telescope_id=3,
+                telescope=None,
+                date='2026-07-22',
+                step_minutes=30,
+            ))
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn('(4) Vesta', out)
+        self.assertIn('Visibility', out)
+        self.assertIn('hakos-e180', out)
+        self.assertIn('horizon', out)
+        self.assertIn('Max altitude', out)
+        self.assertIn('Sunset', out)
+        self.assertIn('Sunrise', out)
+        self.assertIn('Moonrise', out)
+        self.assertIn('Moonset', out)
+        # Must not be the old daytime fallback window
+        self.assertNotIn('06:00 → 18:00', out)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_show(Namespace(
+                query='Vesta',
+                limit=20,
+                no_color=True,
+                telescope_id=None,
+                telescope='hakos-e180',
+                date='2026-07-22',
+                step_minutes=60,
+            ))
+        self.assertEqual(rc, 0)
+        self.assertIn('Visibility', buf.getvalue())
+
+        os.environ.pop('HEVELIUS_DB_NAME')

--- a/tests/test_asteroid_show.py
+++ b/tests/test_asteroid_show.py
@@ -1,0 +1,101 @@
+"""Tests for asteroid name lookup helpers and CLI show presentation."""
+
+import io
+import os
+import unittest
+from argparse import Namespace
+from contextlib import redirect_stdout
+
+from tests.dbtest import use_repository
+from hevelius import db, cmd_asteroid
+
+
+class TestAsteroidNameLookup(unittest.TestCase):
+    def _insert(self, cnx):
+        db.run_query(cnx, """
+            INSERT INTO asteroids (
+                number, designation, name, epoch, mean_anomaly, perihelion_arg,
+                ascending_node, inclination, eccentricity, mean_motion,
+                semimajor_axis, absolute_magnitude, slope_parameter
+            ) VALUES
+            (1, '00001', 'Ceres', 'K25A2', 10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77, 3.34, 0.12),
+            (2, '00002', 'Pallas', 'K25A2', 20.1, 310.0, 173.1, 34.8, 0.229, 0.213, 2.77, 4.13, 0.11),
+            (433, '00433', 'Eros', 'K25A2', 40.0, 150.0, 103.8, 10.8, 0.223, 0.560, 1.46, 10.3, 0.46),
+            (NULL, 'K25A00A', NULL, 'K25A2', 55.2, 120.0, 200.0, 5.1, 0.15, 0.30, 2.10, 18.5, 0.15)
+        """)
+
+    @use_repository
+    def test_find_by_name_number_designation(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        self._insert(cnx)
+
+        by_name = db.asteroids_find_by_query(cnx, 'ceres')
+        self.assertEqual(len(by_name), 1)
+        self.assertEqual(by_name[0][3], 'Ceres')
+
+        by_number = db.asteroids_find_by_query(cnx, '433')
+        self.assertEqual(len(by_number), 1)
+        self.assertEqual(by_number[0][3], 'Eros')
+
+        by_desig = db.asteroids_find_by_query(cnx, 'K25A00A')
+        self.assertEqual(len(by_desig), 1)
+        self.assertIsNone(by_desig[0][3])
+
+        partial = db.asteroids_find_by_query(cnx, 'er')
+        # Eros matches; Ceres does not contain 'er' as substring... wait Ceres has 'er'
+        names = {r[3] for r in partial if r[3]}
+        self.assertIn('Eros', names)
+        self.assertIn('Ceres', names)
+
+        cnx.close()
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_cli_show_exact_and_ambiguous(self, config):
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        cnx = db.connect()
+        self._insert(cnx)
+        cnx.close()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_show(Namespace(query='Ceres', limit=20, no_color=True))
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn('(1) Ceres', out)
+        self.assertIn('Packed designation', out)
+        self.assertIn('00001', out)
+        self.assertIn('Semi-major axis', out)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_show(Namespace(query='er', limit=20, no_color=True))
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn('Multiple matches', out)
+        self.assertIn('Eros', out)
+        self.assertIn('Ceres', out)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_asteroid.asteroids_show(Namespace(query='NoSuchRock', limit=20, no_color=True))
+        self.assertEqual(rc, 1)
+        self.assertIn('No asteroid matching', buf.getvalue())
+
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+
+class TestExtractName(unittest.TestCase):
+    def test_extract_name_from_readable(self):
+        self.assertEqual(
+            cmd_asteroid._extract_name_from_readable('     (1) Ceres              '),
+            'Ceres',
+        )
+        self.assertEqual(
+            cmd_asteroid._extract_name_from_readable('(433) Eros'),
+            'Eros',
+        )
+        self.assertIsNone(cmd_asteroid._extract_name_from_readable('1960 SB1'))
+        self.assertIsNone(cmd_asteroid._extract_name_from_readable('(123456)'))
+        self.assertIsNone(cmd_asteroid._extract_name_from_readable(''))

--- a/tests/test_cmd_asteroid.py
+++ b/tests/test_cmd_asteroid.py
@@ -1,0 +1,144 @@
+"""Unit tests for asteroid CLI helpers (cache age, download skip, load path)."""
+
+import gzip
+import io
+import os
+import tempfile
+import time
+import unittest
+from argparse import Namespace
+from unittest.mock import patch
+
+from hevelius import cmd_asteroid as asteroid
+
+
+class TestMpcorbCacheInfo(unittest.TestCase):
+    """Tests for mpcorb_cache_info freshness metadata."""
+
+    def test_missing_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(asteroid.mpcorb_cache_info(os.path.join(tmp, "missing.DAT")))
+
+    def test_fresh_and_stale(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "MPCORB.DAT")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("x" * 200)
+
+            info = asteroid.mpcorb_cache_info(path)
+            self.assertIsNotNone(info)
+            self.assertTrue(info["fresh"])
+            self.assertEqual(info["size_bytes"], 200)
+            self.assertEqual(info["path"], os.path.abspath(path))
+
+            # Age the file beyond the freshness window.
+            old = time.time() - (asteroid.MPCORB_MAX_AGE_DAYS + 1) * 86400
+            os.utime(path, (old, old))
+            info = asteroid.mpcorb_cache_info(path)
+            self.assertFalse(info["fresh"])
+            self.assertGreater(info["age_seconds"], asteroid.MPCORB_MAX_AGE_DAYS * 86400)
+
+
+class TestDownloadMpcorb(unittest.TestCase):
+    """Tests for download_mpcorb skip / force / error logging."""
+
+    def test_skips_when_fresh_and_logs_reason(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "MPCORB.DAT")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("cached")
+
+            buf = io.StringIO()
+            with patch.object(asteroid, "_cache_dir", return_value=tmp), \
+                 patch.object(asteroid, "_cache_path", return_value=path), \
+                 patch.object(asteroid.urllib.request, "urlretrieve") as retrieve, \
+                 patch("sys.stdout", buf):
+                result = asteroid.download_mpcorb(force=False)
+
+            self.assertEqual(result, path)
+            retrieve.assert_not_called()
+            out = buf.getvalue()
+            self.assertIn("Skipping MPC download", out)
+            self.assertIn("younger than", out)
+            self.assertIn("--force", out)
+
+    def test_redownloads_when_stale(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "MPCORB.DAT")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("old")
+            old = time.time() - (asteroid.MPCORB_MAX_AGE_DAYS + 1) * 86400
+            os.utime(path, (old, old))
+
+            def fake_retrieve(_url, dest):
+                with gzip.open(dest, "wb") as gz:
+                    gz.write(b"new-content")
+
+            buf = io.StringIO()
+            with patch.object(asteroid, "_cache_dir", return_value=tmp), \
+                 patch.object(asteroid, "_cache_path", return_value=path), \
+                 patch.object(asteroid.urllib.request, "urlretrieve", side_effect=fake_retrieve), \
+                 patch("sys.stdout", buf):
+                result = asteroid.download_mpcorb(force=False)
+
+            self.assertEqual(result, path)
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), b"new-content")
+            out = buf.getvalue()
+            self.assertIn("older than", out)
+            self.assertIn("Downloading", out)
+
+    def test_force_redownloads_even_when_fresh(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "MPCORB.DAT")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("fresh")
+
+            def fake_retrieve(_url, dest):
+                with gzip.open(dest, "wb") as gz:
+                    gz.write(b"forced")
+
+            buf = io.StringIO()
+            with patch.object(asteroid, "_cache_dir", return_value=tmp), \
+                 patch.object(asteroid, "_cache_path", return_value=path), \
+                 patch.object(asteroid.urllib.request, "urlretrieve", side_effect=fake_retrieve), \
+                 patch("sys.stdout", buf):
+                result = asteroid.download_mpcorb(force=True)
+
+            self.assertEqual(result, path)
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), b"forced")
+            self.assertIn("--force", buf.getvalue())
+
+    def test_logs_download_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "MPCORB.DAT")
+            err = asteroid.urllib.error.URLError("network down")
+
+            buf_out = io.StringIO()
+            buf_err = io.StringIO()
+            with patch.object(asteroid, "_cache_dir", return_value=tmp), \
+                 patch.object(asteroid, "_cache_path", return_value=path), \
+                 patch.object(asteroid.urllib.request, "urlretrieve", side_effect=err), \
+                 patch("sys.stdout", buf_out), \
+                 patch("sys.stderr", buf_err):
+                with self.assertRaises(asteroid.urllib.error.URLError):
+                    asteroid.download_mpcorb(force=True)
+
+            self.assertIn("failed to download", buf_err.getvalue())
+
+
+class TestAsteroidsLoad(unittest.TestCase):
+    """Tests for the asteroid load CLI entry point."""
+
+    def test_missing_file_returns_error(self):
+        args = Namespace(file="/no/such/MPCORB.DAT", limit=None)
+        buf = io.StringIO()
+        with patch("sys.stderr", buf):
+            rc = asteroid.asteroids_load(args)
+        self.assertEqual(rc, 1)
+        self.assertIn("MPCORB not found", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cmd_asteroid2.py
+++ b/tests/test_cmd_asteroid2.py
@@ -1,0 +1,155 @@
+"""Unit tests for MPCORB parsing and asteroid visibility helpers."""
+
+import unittest
+
+from astropy.coordinates import EarthLocation
+from astropy import units as u
+
+from hevelius import cmd_asteroid
+
+
+def _mpcorb_line(designation: str, H: str = " 3.34", G: str = " 0.15",
+                 epoch: str = "K25A2",
+                 M: str = " 10.00000", peri: str = " 73.00000",
+                 node: str = " 80.00000", inc: str = " 10.00000",
+                 e: str = " 0.0800000", n: str = " 0.21400000",
+                 a: str = "  2.7600000") -> str:
+    """Build a minimal fixed-width MPCORB line (>= 104 chars)."""
+    # Columns are 1-based in the MPC docs; slices below are 0-based.
+    line = [" "] * 104
+    des = designation.ljust(7)[:7]
+    line[0:7] = list(des)
+    line[8:13] = list(H.rjust(5)[:5])
+    line[14:19] = list(G.rjust(5)[:5])
+    line[20:25] = list(epoch.ljust(5)[:5])
+    line[26:35] = list(M.rjust(9)[:9])
+    line[37:46] = list(peri.rjust(9)[:9])
+    line[48:57] = list(node.rjust(9)[:9])
+    line[59:68] = list(inc.rjust(9)[:9])
+    line[70:79] = list(e.rjust(9)[:9])
+    line[80:91] = list(n.rjust(11)[:11])
+    line[92:103] = list(a.rjust(11)[:11])
+    return "".join(line)
+
+
+class TestUnpackPermanentNumber(unittest.TestCase):
+    def test_plain_numbers(self):
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("00001"), 1)
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("00433"), 433)
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("10000"), 10000)
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("99999"), 99999)
+        # Trailing spaces from the 7-char MPCORB field
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("00001  "), 1)
+
+    def test_letter_coded_numbers(self):
+        # A0345 → 10*10000 + 345 = 100345
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("A0345"), 100345)
+        # a0017 → 36*10000 + 17 = 360017
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("a0017"), 360017)
+        # K3289 → 20*10000 + 3289 = 203289
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("K3289"), 203289)
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("A0001"), 100001)
+
+    def test_tilde_base62_numbers(self):
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("~0000"), 620000)
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("~000z"), 620061)
+        # ~AZaz = 10*62^3 + 35*62^2 + 36*62 + 61 = 2520113 → 3140113
+        self.assertEqual(cmd_asteroid._unpack_permanent_number("~AZaz"), 3140113)
+
+    def test_provisional_returns_none(self):
+        self.assertIsNone(cmd_asteroid._unpack_permanent_number("K25A00A"))
+        self.assertIsNone(cmd_asteroid._unpack_permanent_number("J98S53D"))
+        self.assertIsNone(cmd_asteroid._unpack_permanent_number("PLS2040"))
+        self.assertIsNone(cmd_asteroid._unpack_permanent_number(""))
+        self.assertIsNone(cmd_asteroid._unpack_permanent_number("J013S"))  # satellite
+
+
+class TestParseMpcorbLine(unittest.TestCase):
+    def test_numbered_asteroids(self):
+        for desig, expected in [
+            ("00001", 1),
+            ("00433", 433),
+            ("10000", 10000),
+            ("A0001", 100001),
+            ("~0000", 620000),
+        ]:
+            parsed = cmd_asteroid._parse_mpcorb_line(_mpcorb_line(desig))
+            self.assertIsNotNone(parsed, desig)
+            self.assertEqual(parsed["number"], expected, desig)
+            self.assertEqual(parsed["designation"], desig.strip())
+            self.assertAlmostEqual(parsed["semimajor_axis"], 2.76, places=2)
+
+    def test_provisional_has_null_number(self):
+        parsed = cmd_asteroid._parse_mpcorb_line(_mpcorb_line("K25A00A"))
+        self.assertIsNotNone(parsed)
+        self.assertIsNone(parsed["number"])
+        self.assertEqual(parsed["designation"], "K25A00A")
+
+    def test_short_or_header_line_rejected(self):
+        self.assertIsNone(cmd_asteroid._parse_mpcorb_line("too short"))
+        # Separator rows in MPCORB start with a run of dashes in the designation field
+        self.assertIsNone(cmd_asteroid._parse_mpcorb_line(_mpcorb_line("--------")))
+
+
+class TestApparentMagnitude(unittest.TestCase):
+    def test_opposition_like_geometry(self):
+        # At r=delta=1 AU and phase≈0, mag ≈ H
+        mag = cmd_asteroid._apparent_magnitude(10.0, 0.15, 1.0, 1.0, 0.0)
+        self.assertAlmostEqual(mag, 10.0, places=2)
+
+    def test_farther_is_fainter(self):
+        near = cmd_asteroid._apparent_magnitude(10.0, 0.15, 1.0, 1.0, 10.0)
+        far = cmd_asteroid._apparent_magnitude(10.0, 0.15, 2.0, 2.0, 10.0)
+        self.assertGreater(far, near)
+
+
+class TestVisibilityCurve(unittest.TestCase):
+    def test_curve_returns_samples_and_flags(self):
+        # Ceres-like elements (approximate); epoch packed K25A2
+        row = (
+            1, "00001", "K25A2",
+            10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77,
+            3.34, 0.12,
+        )
+        location = EarthLocation(lat=52.2 * u.deg, lon=21.0 * u.deg, height=100 * u.m)
+        result = cmd_asteroid.compute_asteroid_visibility_curve(
+            row, location, "2026-06-15", step_minutes=30,
+        )
+        self.assertIn("night_start", result)
+        self.assertIn("night_end", result)
+        self.assertLess(result["night_start"], result["night_end"])
+        self.assertGreater(len(result["samples"]), 1)
+        sample = result["samples"][0]
+        self.assertIn("altitude_deg", sample)
+        self.assertIn("azimuth_deg", sample)
+        self.assertIn("apparent_magnitude", sample)
+        self.assertIsInstance(result["visible"], bool)
+        self.assertTrue(result["has_magnitude_estimate"])
+        self.assertIsNotNone(result["apparent_magnitude_at_max"])
+
+    def test_missing_h_skips_magnitude(self):
+        row = (
+            1, "00001", "K25A2",
+            10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77,
+            None, 0.15,
+        )
+        location = EarthLocation(lat=52.2 * u.deg, lon=21.0 * u.deg, height=100 * u.m)
+        result = cmd_asteroid.compute_asteroid_visibility_curve(
+            row, location, "2026-06-15", step_minutes=60,
+        )
+        self.assertFalse(result["has_magnitude_estimate"])
+        self.assertIsNone(result["apparent_magnitude_at_max"])
+        self.assertTrue(all(s["apparent_magnitude"] is None for s in result["samples"]))
+
+
+class TestIersConfigLazy(unittest.TestCase):
+    def test_import_does_not_require_prior_iers_config(self):
+        # Visibility entry points call _configure_iers_for_planning(); the
+        # helper is idempotent and safe to call again.
+        cmd_asteroid._configure_iers_for_planning()
+        cmd_asteroid._configure_iers_for_planning()
+        self.assertIsNone(cmd_asteroid.iers.conf.auto_max_age)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cmd_asteroid2.py
+++ b/tests/test_cmd_asteroid2.py
@@ -13,10 +13,12 @@ def _mpcorb_line(designation: str, H: str = " 3.34", G: str = " 0.15",
                  M: str = " 10.00000", peri: str = " 73.00000",
                  node: str = " 80.00000", inc: str = " 10.00000",
                  e: str = " 0.0800000", n: str = " 0.21400000",
-                 a: str = "  2.7600000") -> str:
-    """Build a minimal fixed-width MPCORB line (>= 104 chars)."""
+                 a: str = "  2.7600000",
+                 readable: str = "") -> str:
+    """Build a minimal fixed-width MPCORB line (>= 104 chars; 194+ with readable)."""
     # Columns are 1-based in the MPC docs; slices below are 0-based.
-    line = [" "] * 104
+    length = 194 if readable else 104
+    line = [" "] * length
     des = designation.ljust(7)[:7]
     line[0:7] = list(des)
     line[8:13] = list(H.rjust(5)[:5])
@@ -29,6 +31,8 @@ def _mpcorb_line(designation: str, H: str = " 3.34", G: str = " 0.15",
     line[70:79] = list(e.rjust(9)[:9])
     line[80:91] = list(n.rjust(11)[:11])
     line[92:103] = list(a.rjust(11)[:11])
+    if readable:
+        line[166:194] = list(readable.ljust(28)[:28])
     return "".join(line)
 
 
@@ -84,6 +88,26 @@ class TestParseMpcorbLine(unittest.TestCase):
         self.assertIsNotNone(parsed)
         self.assertIsNone(parsed["number"])
         self.assertEqual(parsed["designation"], "K25A00A")
+        self.assertIsNone(parsed["name"])
+
+    def test_extracts_proper_name_from_readable_designation(self):
+        parsed = cmd_asteroid._parse_mpcorb_line(
+            _mpcorb_line("00001", readable="     (1) Ceres              ")
+        )
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["number"], 1)
+        self.assertEqual(parsed["name"], "Ceres")
+
+        parsed = cmd_asteroid._parse_mpcorb_line(
+            _mpcorb_line("00433", readable="   (433) Eros               ")
+        )
+        self.assertEqual(parsed["name"], "Eros")
+
+        # Provisional readable designation has no proper name
+        parsed = cmd_asteroid._parse_mpcorb_line(
+            _mpcorb_line("K25A00A", readable="           2025 AA           ")
+        )
+        self.assertIsNone(parsed["name"])
 
     def test_short_or_header_line_rejected(self):
         self.assertIsNone(cmd_asteroid._parse_mpcorb_line("too short"))
@@ -106,8 +130,9 @@ class TestApparentMagnitude(unittest.TestCase):
 class TestVisibilityCurve(unittest.TestCase):
     def test_curve_returns_samples_and_flags(self):
         # Ceres-like elements (approximate); epoch packed K25A2
+        # Tuple shape: number, designation, name, epoch, M, peri, node, i, e, n, a, H, G
         row = (
-            1, "00001", "K25A2",
+            1, "00001", "Ceres", "K25A2",
             10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77,
             3.34, 0.12,
         )
@@ -129,7 +154,7 @@ class TestVisibilityCurve(unittest.TestCase):
 
     def test_missing_h_skips_magnitude(self):
         row = (
-            1, "00001", "K25A2",
+            1, "00001", None, "K25A2",
             10.5, 73.6, 80.3, 10.6, 0.078, 0.214, 2.77,
             None, 0.15,
         )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -28,7 +28,7 @@ class DbTest(unittest.TestCase):
         version = db.version_get(conn)
         conn.close()
 
-        self.assertEqual(version, 23)
+        self.assertEqual(version, 24)
 
     @use_repository
     def test_sensor(self, config):

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -70,6 +70,10 @@ class TestOpenAPISpec(unittest.TestCase):
             "/api/catalogs/list",
             "/api/asteroids",
             "/api/asteroids/{asteroid_id}",
+            "/api/asteroid-tags",
+            "/api/asteroid-tags/{tag_id}",
+            "/api/asteroids/{asteroid_id}/tags",
+            "/api/asteroids/{asteroid_id}/tags/{tag_id}",
         }
         self.assertEqual(paths, expected, "OpenAPI paths should match implemented routes")
 

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -68,6 +68,8 @@ class TestOpenAPISpec(unittest.TestCase):
             "/api/catalogs",
             "/api/catalogs/search",
             "/api/catalogs/list",
+            "/api/asteroids",
+            "/api/asteroids/{asteroid_id}",
         }
         self.assertEqual(paths, expected, "OpenAPI paths should match implemented routes")
 

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -70,6 +70,7 @@ class TestOpenAPISpec(unittest.TestCase):
             "/api/catalogs/list",
             "/api/asteroids",
             "/api/asteroids/{asteroid_id}",
+            "/api/asteroids/{asteroid_id}/visibility",
             "/api/asteroid-tags",
             "/api/asteroid-tags/{tag_id}",
             "/api/asteroids/{asteroid_id}/tags",


### PR DESCRIPTION
## Summary
This PR adds comprehensive asteroid (minor planet) search and detail endpoints to the API, allowing users to query asteroids with filtering, sorting, and pagination capabilities.

## Key Changes

### API Endpoints
- **GET/POST `/api/asteroids`** - List asteroids with pagination, sorting, and filtering
  - Supports filtering by designation (partial match), MPC number, numbered/unnumbered status, and absolute magnitude range
  - Sortable by: number, designation, absolute_magnitude, semimajor_axis, eccentricity, inclination, mean_motion, epoch
  - Paginated results with configurable page size (1-1000 items)
  - Both GET (query parameters) and POST (JSON body) methods supported

- **GET `/api/asteroids/{asteroid_id}`** - Retrieve single asteroid details by internal ID
  - Returns full orbital element set including all MPC orbital parameters
  - Returns 404 if asteroid not found

### Database Layer (`hevelius/db.py`)
- Added `asteroids_build_where()` - Helper to construct WHERE clauses with filter parameters
- Added `asteroids_count()` - Count asteroids matching filters
- Added `asteroids_search()` - Search with filters, sorting, and pagination
- Added `asteroid_get_by_id()` - Fetch single asteroid by ID
- Defined `ASTEROID_SORT_FIELDS` constant for validation

### API Schema & Validation (`heveliusbackend/app.py`)
- `AsteroidSchema` - Marshmallow schema for asteroid data serialization
- `AsteroidsListRequestSchema` - Validates query/body parameters with:
  - Range validation for page/per_page
  - Enum validation for sort fields and order
  - Custom validation ensuring mag_min ≤ mag_max
- `AsteroidsListResponseSchema` - Response format with pagination metadata
- `AsteroidDetailResponseSchema` - Single asteroid response wrapper
- `AsteroidsListResource` - MethodView handling GET/POST list operations
- `AsteroidDetailResource` - MethodView handling single asteroid retrieval

### OpenAPI Documentation
- Added complete OpenAPI 3.0 schema definitions for all asteroid endpoints
- Documented all parameters, response formats, and error codes (404, 422)

### Tests (`tests/test_api_asteroids.py`)
- Comprehensive test suite covering:
  - Basic listing and pagination
  - Sorting by various fields (ascending/descending)
  - Filtering by number, designation, numbered status, and magnitude range
  - POST method with JSON body
  - Single asteroid detail retrieval
  - Unauthorized access (401)
  - Invalid parameter validation (422)
  - Not found scenarios (404)

## Implementation Details
- All endpoints require JWT authentication (`@jwt_required()`)
- NULL handling for unnumbered asteroids (number field is nullable)
- Sorting with NULLS LAST for numbered field to place unnumbered asteroids at end
- Efficient pagination using LIMIT/OFFSET
- Case-insensitive partial matching for designation filter
- Comprehensive input validation with meaningful error messages

https://claude.ai/code/session_01QvQ7KmmwvS29AVbhRH6BF4