### PR TITLE
Implement `hevelius doctor` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 ## 0.7.0 (unreleased)
 
 - Bug: Fixed hevelius db migrate command - it does not throw anymore.
+- CLI: `hevelius doctor` checks whether the tool starts, where the config was
+  loaded from, DB connectivity and schema version (against `db/*.psql`),
+  presence of and recent errors in the gunicorn access/error logs, and
+  whether `jwt.secret-key`, `web.base-url`, and `smtp.*` were changed from
+  their example/default values. `hevelius doctor --mail-check EMAIL` sends a
+  real test email through the configured SMTP server. New `logs.path` config
+  section (`HEVELIUS_LOG_PATH` env var, default `/var/log/hevelius`).
+- Bug: `hevelius.config.load_config()` deep-copies its defaults now, so an
+  env var override no longer leaks into later `load_config()` calls in the
+  same process after the env var is unset.
+- Bug: `bin/hevelius` now propagates command exit codes via `sys.exit()`
+  instead of always exiting 0.
 
 ## 0.6.0 (2026-07-24)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Status as of July 2026:
 - **Ability to search based on distance**. Implemented proper Haversine formula.
 - **Database management**: Schema versioning and upgrades, backup, etc.
 - **Configuration**: Config file support and some limited environment variables.
+- **Doctor**: `hevelius doctor` checks that the install is configured correctly (config, DB
+  connectivity/schema, logs, JWT/web-url/SMTP settings) and can send a test email.
 
 ## Hevelius web interface
 

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -11,6 +11,7 @@ sys.path.append(".")
 
 # pylint: disable=wrong-import-position
 from hevelius.cli.basic import db_version, hevelius_version, config_show, backup
+from hevelius.cli.doctor import doctor
 from hevelius.stats import stats, groups
 from hevelius.cli.db_migrate import migrate
 from hevelius.cli.repo import repo
@@ -66,6 +67,10 @@ def run():
 
     subparsers.add_parser('config', help="Shows current Hevelius (DB,file repository) configuration.")
     subparsers.add_parser('version', help="Shows the current Hevelius version.")
+
+    doctor_parser = subparsers.add_parser('doctor', help="Checks that Hevelius is configured and running correctly.")
+    doctor_parser.add_argument("--mail-check", metavar="EMAIL", help="Send a test email to EMAIL using the configured SMTP settings.")
+    doctor_parser.add_argument("--no-color", help="Disable ANSI colors in the output", action='store_true')
 
     db_parser = subparsers.add_parser('db', help="Manages database")
     db_subparsers = db_parser.add_subparsers(help="Commands related to database", dest="db_command")
@@ -563,6 +568,8 @@ def run():
         return catalog_mgmt_parser.print_help() or 1
     if args.command == "config":
         return config_show()  # see cmd_basic.py
+    if args.command == "doctor":
+        return doctor(args)  # see cli/doctor.py
     if args.command == "repo":
         return repo(args)  # see cmd_repo.py
     if args.command == "version":
@@ -864,4 +871,4 @@ def version():
 
 
 if __name__ == '__main__':
-    run()
+    sys.exit(run())

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -6,13 +6,14 @@ The command-line can be accessed the following way:
 ```shell
 $ python bin/hevelius --help
 usage: hevelius [-h]
-                {config,version,db,repo,task,catalog,filter,sensor,project,telescope,user,asteroid} ...
+                {config,version,doctor,db,repo,task,catalog,filter,sensor,project,telescope,user,asteroid} ...
 
 positional arguments:
-  {config,version,db,repo,task,catalog,filter,sensor,project,telescope,user,asteroid}
+  {config,version,doctor,db,repo,task,catalog,filter,sensor,project,telescope,user,asteroid}
                         commands
     config              Shows current Hevelius (DB,file repository) configuration.
     version             Shows the current Hevelius version.
+    doctor              Checks that Hevelius is configured and running correctly.
     db                  Manages database
     repo                Manages files repository on local storage.
     task                Task-related commands
@@ -40,6 +41,32 @@ hevelius sensor list
 hevelius project list
 hevelius telescope list
 hevelius user list
+```
+
+## Doctor
+
+`hevelius doctor` runs a series of sanity checks on the local installation
+and prints an `OK` / `WARN` / `FAIL` report: whether the tool starts, where
+the config file was loaded from, whether the database is reachable and on
+the latest schema, whether the gunicorn access/error logs are present and
+free of recent errors, and whether `jwt.secret-key`, `web.base-url`, and
+the `smtp.*` settings have been changed from their example/default values.
+It exits with status 1 if any check fails.
+
+```shell
+hevelius doctor
+hevelius doctor --no-color
+```
+
+Log files are looked up under `logs.path` in the config (`HEVELIUS_LOG_PATH`
+env var), which defaults to `/var/log/hevelius` (matching
+`doc/gunicorn-hevelius.service`).
+
+Use `--mail-check EMAIL` to actually send a test message through the
+configured SMTP server, to verify outgoing email works end to end:
+
+```shell
+hevelius doctor --mail-check you@example.com
 ```
 
 ## Task list

--- a/hevelius/cli/doctor.py
+++ b/hevelius/cli/doctor.py
@@ -1,0 +1,290 @@
+"""
+`hevelius doctor` - sanity checks for the local installation: config, DB
+connectivity/schema, logs, and the JWT/web-url/SMTP settings that are easy
+to leave at their example values.
+"""
+
+import re
+import sys
+from os import listdir
+from os.path import isfile, join
+
+from hevelius import db
+from hevelius.cli.basic import hevelius_version
+from hevelius.config import load_config
+from hevelius.mailer import send_email
+
+OK = "OK"
+WARN = "WARN"
+FAIL = "FAIL"
+INFO = "INFO"
+
+_LABELS = {
+    OK: "32",
+    WARN: "33",
+    FAIL: "31",
+    INFO: "36",
+}
+
+_JWT_EXAMPLE_SECRET = "your-secret-key-here"
+_WEB_EXAMPLE_URL = "https://hevelius.example.com"
+_WEB_DEFAULT_URL = "http://localhost:3000"
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_LOG_ERROR_RE = re.compile(r"\b(ERROR|CRITICAL|Traceback)\b")
+_LOG_TAIL_LINES = 2000
+
+
+def _ansi(code, text, enabled):
+    if not enabled:
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def _print_check(name, status, message, color):
+    tag = _ansi(_LABELS[status], f"[{status:>4}]", color)
+    print(f"{tag} {name:<14} {message}")
+
+
+def check_startup():
+    """Verify the interpreter and core dependencies needed to run at all."""
+    missing = []
+    for mod in ("yaml", "argon2"):
+        try:
+            __import__(mod)
+        except ImportError:
+            missing.append(mod)
+    if missing:
+        return FAIL, f"Missing required Python package(s): {', '.join(missing)}"
+    return OK, f"Hevelius {hevelius_version() or 'unknown version'} starting fine (Python {sys.version.split()[0]})"
+
+
+def check_config(config, meta):
+    """Report where the configuration was loaded from."""
+    if meta["base_source"] == "file":
+        status = OK
+        message = f"Loaded from {meta['base_config_path']}"
+    else:
+        status = WARN
+        message = (
+            "No hevelius.yaml found (expected at hevelius/hevelius.yaml); using built-in defaults. "
+            "Copy hevelius/hevelius.yaml.example to hevelius/hevelius.yaml and edit it."
+        )
+    if meta["environment_overrides"]:
+        message += f" Environment overrides: {', '.join(meta['environment_overrides'])}."
+    return status, message
+
+
+def check_database(config):
+    """Try to connect to the configured database."""
+    dbcfg = config["database"]
+    where = f"{dbcfg['type']} database '{dbcfg['database']}' at {dbcfg['host']}:{dbcfg['port']} as {dbcfg['user']}"
+    try:
+        cnx = db.connect()
+    except Exception as e:  # pylint: disable=broad-except
+        return FAIL, f"Could not connect to {where}: {e}"
+    cnx.close()
+    return OK, f"Connected to {where}"
+
+
+def latest_migration_version(schema_dir="db"):
+    """Highest numbered *.psql migration script under schema_dir, or None."""
+    try:
+        entries = listdir(schema_dir)
+    except OSError:
+        return None
+
+    versions = []
+    for f in entries:
+        if not isfile(join(schema_dir, f)) or not f.endswith("psql"):
+            continue
+        try:
+            versions.append(int(f[:2]))
+        except ValueError:
+            continue
+    return max(versions) if versions else None
+
+
+def check_schema(db_ok):
+    """Compare the DB schema_version against the newest migration script."""
+    if not db_ok:
+        return INFO, "Skipped (database unreachable)"
+
+    latest = latest_migration_version()
+    if latest is None:
+        return WARN, "Could not determine the latest schema version from db/*.psql"
+
+    try:
+        cnx = db.connect()
+        current = db.version_get(cnx)
+        cnx.close()
+    except Exception as e:  # pylint: disable=broad-except
+        return FAIL, f"Could not read the DB schema version: {e}"
+
+    if current == latest:
+        return OK, f"DB schema is up to date (version {current})"
+    if current < latest:
+        return WARN, f"DB schema is version {current}, latest is {latest}; run 'hevelius db migrate'"
+    return WARN, f"DB schema is version {current}, newer than the latest known migration ({latest})"
+
+
+def check_logs(config):
+    """Look for the gunicorn access/error logs at the configured path."""
+    log_dir = (config.get("logs") or {}).get("path") or "/var/log/hevelius"
+    found = [p for p in (join(log_dir, "error.log"), join(log_dir, "access.log")) if isfile(p)]
+    if not found:
+        return WARN, (
+            f"No log files found in {log_dir} (expected error.log / access.log); "
+            "set logs.path in config if logs live elsewhere."
+        ), found
+    return OK, f"Found: {', '.join(found)}", found
+
+
+def check_log_errors(log_files):
+    """Scan the tail of each log file for ERROR/CRITICAL/Traceback lines."""
+    if not log_files:
+        return INFO, "Skipped (no log files found)"
+
+    details = []
+    total = 0
+    for path in log_files:
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                tail = f.readlines()[-_LOG_TAIL_LINES:]
+        except OSError as e:
+            details.append(f"{path}: could not read ({e})")
+            continue
+        count = sum(1 for line in tail if _LOG_ERROR_RE.search(line))
+        if count:
+            total += count
+            details.append(f"{path}: {count} error-like line(s) in the last {len(tail)} line(s)")
+
+    if total == 0:
+        return OK, "No errors found in the recent log lines"
+    return WARN, "; ".join(details)
+
+
+def check_jwt(config):
+    """Make sure the JWT secret was changed from the example value."""
+    secret = (config.get("jwt") or {}).get("secret-key")
+    if not secret:
+        return FAIL, "jwt.secret-key is not set; the API will refuse to start"
+    if secret == _JWT_EXAMPLE_SECRET:
+        return FAIL, "jwt.secret-key is still the example placeholder value; change it"
+    if len(secret) < 32:
+        return WARN, f"jwt.secret-key is only {len(secret)} character(s) long; use at least 32"
+    return OK, "jwt.secret-key is set and differs from the example"
+
+
+def check_web_url(config):
+    """Make sure web.base-url was changed from the example/default value."""
+    url = (config.get("web") or {}).get("base-url")
+    if not url:
+        return FAIL, "web.base-url is not set; links in emails (e.g. password reset) will be broken"
+    if url == _WEB_EXAMPLE_URL:
+        return WARN, f"web.base-url is still the example placeholder value ({url})"
+    if url == _WEB_DEFAULT_URL:
+        return WARN, f"web.base-url is still the built-in default ({url}); set it to your real frontend URL"
+    return OK, f"web.base-url is set to {url}"
+
+
+def check_smtp(config):
+    """Sanity-check the SMTP settings without actually sending anything."""
+    smtp = config.get("smtp") or {}
+    host = smtp.get("host")
+    if not host:
+        return WARN, "smtp.host is not set; outgoing email will be logged instead of sent"
+
+    problems = []
+
+    try:
+        port = int(smtp.get("port"))
+        if not 1 <= port <= 65535:
+            problems.append(f"port {smtp.get('port')} is out of range")
+    except (TypeError, ValueError):
+        problems.append(f"port {smtp.get('port')!r} is not a valid number")
+
+    from_addr = smtp.get("from-addr")
+    if not from_addr or not _EMAIL_RE.match(from_addr):
+        problems.append(f"from-addr {from_addr!r} does not look like a valid email address")
+
+    if bool(smtp.get("username")) != bool(smtp.get("password")):
+        problems.append("username and password should both be set, or both left empty")
+
+    if problems:
+        return WARN, f"smtp.host={host}: " + "; ".join(problems)
+    return OK, f"smtp.host={host}:{smtp.get('port')} looks sane (from-addr={from_addr})"
+
+
+def mail_check(addr, color=True):
+    """Send a real test email to addr using the configured SMTP settings."""
+    print(f"Sending test email to {addr} ...")
+    config = load_config()
+    smtp = config.get("smtp") or {}
+
+    if not smtp.get("host"):
+        _print_check("Mail check", FAIL, "smtp.host is not set; there is nothing to test.", color)
+        return 1
+
+    try:
+        sent = send_email(
+            addr,
+            "Hevelius doctor test email",
+            "This is a test message sent by 'hevelius doctor --mail-check' to verify SMTP delivery.",
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        _print_check("Mail check", FAIL, f"Failed to send via {smtp['host']}:{smtp.get('port')}: {e}", color)
+        return 1
+
+    if sent:
+        _print_check("Mail check", OK, f"Test email sent to {addr} via {smtp['host']}:{smtp.get('port')}", color)
+        return 0
+
+    _print_check("Mail check", FAIL, f"Test email to {addr} was not sent.", color)
+    return 1
+
+
+def doctor(args):
+    """Run all `hevelius doctor` checks and print a report."""
+    color = not getattr(args, "no_color", False)
+
+    addr = getattr(args, "mail_check", None)
+    if addr:
+        return mail_check(addr, color)
+
+    print("Hevelius Doctor")
+    print("=" * 15)
+    print()
+
+    config, meta = load_config(return_metadata=True)
+
+    results = [("Startup", *check_startup()), ("Configuration", *check_config(config, meta))]
+
+    db_status, db_message = check_database(config)
+    results.append(("Database", db_status, db_message))
+    results.append(("DB schema", *check_schema(db_status == OK)))
+
+    _log_status, log_message, log_files = check_logs(config)
+    results.append(("Logs", _log_status, log_message))
+    results.append(("Log errors", *check_log_errors(log_files)))
+
+    results.append(("JWT secret", *check_jwt(config)))
+    results.append(("Web URL", *check_web_url(config)))
+    results.append(("SMTP", *check_smtp(config)))
+
+    for name, status, message in results:
+        _print_check(name, status, message, color)
+
+    counts = {}
+    for _, status, _msg in results:
+        counts[status] = counts.get(status, 0) + 1
+    fails = counts.get(FAIL, 0)
+    warns = counts.get(WARN, 0)
+
+    print()
+    print(f"{len(results)} check(s): {counts.get(OK, 0)} OK, {warns} warning(s), {fails} failure(s).")
+    if not fails and not warns:
+        print("Everything looks good!")
+    print()
+    print("Tip: 'hevelius doctor --mail-check you@example.com' sends a real test email over SMTP.")
+
+    return 1 if fails else 0

--- a/hevelius/config.py
+++ b/hevelius/config.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import yaml
 from pathlib import Path
@@ -32,6 +33,9 @@ DEFAULT_CONFIG = {
         'use-tls': True,
         'from-addr': 'noreply@hevelius.local',
     },
+    'logs': {
+        'path': '/var/log/hevelius',
+    },
 }
 
 
@@ -44,7 +48,11 @@ def load_config(return_metadata=False):
     # if loaded_config:
     #     return loaded_config.copy()
 
-    config_dict = DEFAULT_CONFIG.copy()
+    # Deep copy: DEFAULT_CONFIG's nested dicts must never be mutated in place,
+    # or an env var override picked up in one call would leak into every
+    # later load_config() call in this process, even after the env var is
+    # unset (a shallow .copy() only copies the top-level section keys).
+    config_dict = copy.deepcopy(DEFAULT_CONFIG)
     metadata = {
         'base_source': 'defaults',
         'base_config_path': None,
@@ -83,6 +91,7 @@ def load_config(return_metadata=False):
         'HEVELIUS_SMTP_USERNAME': ('smtp', 'username'),
         'HEVELIUS_SMTP_PASSWORD': ('smtp', 'password'),
         'HEVELIUS_SMTP_FROM': ('smtp', 'from-addr'),
+        'HEVELIUS_LOG_PATH': ('logs', 'path'),
     }
 
     for env_var, (section, key) in env_mapping.items():

--- a/hevelius/hevelius.yaml.example
+++ b/hevelius/hevelius.yaml.example
@@ -27,3 +27,8 @@ smtp:
   password: secret2
   use-tls: true
   from-addr: noreply@example.com
+
+logs:
+  # Directory where the gunicorn access/error logs are written
+  # (see doc/gunicorn-hevelius.service). Used by `hevelius doctor`.
+  path: /var/log/hevelius

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -1,0 +1,237 @@
+"""Tests for `hevelius doctor` (hevelius.cli.doctor)."""
+
+import io
+import os
+import tempfile
+import unittest
+from argparse import Namespace
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from tests.dbtest import use_repository
+from hevelius.cli import doctor
+
+
+class TestPureChecks(unittest.TestCase):
+    """Checks that don't need a database or filesystem log directory."""
+
+    def test_check_config_from_file(self):
+        meta = {
+            "base_source": "file",
+            "base_config_path": "/etc/hevelius/hevelius.yaml",
+            "environment_overrides": [],
+        }
+        status, message = doctor.check_config({}, meta)
+        self.assertEqual(status, doctor.OK)
+        self.assertIn("/etc/hevelius/hevelius.yaml", message)
+
+    def test_check_config_defaults_warns(self):
+        meta = {"base_source": "defaults", "base_config_path": None, "environment_overrides": ["HEVELIUS_DB_HOST"]}
+        status, message = doctor.check_config({}, meta)
+        self.assertEqual(status, doctor.WARN)
+        self.assertIn("built-in defaults", message)
+        self.assertIn("HEVELIUS_DB_HOST", message)
+
+    def test_check_jwt_unset(self):
+        status, _ = doctor.check_jwt({"jwt": {"secret-key": None}})
+        self.assertEqual(status, doctor.FAIL)
+
+    def test_check_jwt_example_value(self):
+        status, message = doctor.check_jwt({"jwt": {"secret-key": "your-secret-key-here"}})
+        self.assertEqual(status, doctor.FAIL)
+        self.assertIn("example", message)
+
+    def test_check_jwt_too_short(self):
+        status, _ = doctor.check_jwt({"jwt": {"secret-key": "short"}})
+        self.assertEqual(status, doctor.WARN)
+
+    def test_check_jwt_ok(self):
+        status, _ = doctor.check_jwt({"jwt": {"secret-key": "x" * 40}})
+        self.assertEqual(status, doctor.OK)
+
+    def test_check_web_url_unset(self):
+        status, _ = doctor.check_web_url({"web": {"base-url": None}})
+        self.assertEqual(status, doctor.FAIL)
+
+    def test_check_web_url_example(self):
+        status, _ = doctor.check_web_url({"web": {"base-url": "https://hevelius.example.com"}})
+        self.assertEqual(status, doctor.WARN)
+
+    def test_check_web_url_default(self):
+        status, _ = doctor.check_web_url({"web": {"base-url": "http://localhost:3000"}})
+        self.assertEqual(status, doctor.WARN)
+
+    def test_check_web_url_ok(self):
+        status, _ = doctor.check_web_url({"web": {"base-url": "https://obs.example.org"}})
+        self.assertEqual(status, doctor.OK)
+
+    def test_check_smtp_not_configured(self):
+        status, message = doctor.check_smtp({"smtp": {"host": None}})
+        self.assertEqual(status, doctor.WARN)
+        self.assertIn("not set", message)
+
+    def test_check_smtp_ok(self):
+        status, _ = doctor.check_smtp({
+            "smtp": {"host": "smtp.example.com", "port": 587, "from-addr": "a@example.com",
+                     "username": "u", "password": "p"},
+        })
+        self.assertEqual(status, doctor.OK)
+
+    def test_check_smtp_bad_port(self):
+        status, message = doctor.check_smtp({
+            "smtp": {"host": "smtp.example.com", "port": 99999, "from-addr": "a@example.com"},
+        })
+        self.assertEqual(status, doctor.WARN)
+        self.assertIn("port", message)
+
+    def test_check_smtp_bad_from_addr(self):
+        status, message = doctor.check_smtp({
+            "smtp": {"host": "smtp.example.com", "port": 587, "from-addr": "not-an-email"},
+        })
+        self.assertEqual(status, doctor.WARN)
+        self.assertIn("from-addr", message)
+
+    def test_check_smtp_lopsided_credentials(self):
+        status, message = doctor.check_smtp({
+            "smtp": {"host": "smtp.example.com", "port": 587, "from-addr": "a@example.com", "username": "u"},
+        })
+        self.assertEqual(status, doctor.WARN)
+        self.assertIn("username and password", message)
+
+    def test_check_startup_ok(self):
+        status, message = doctor.check_startup()
+        self.assertEqual(status, doctor.OK)
+        self.assertIn("Python", message)
+
+    def test_check_startup_missing_module(self):
+        with patch("builtins.__import__", side_effect=ImportError):
+            status, message = doctor.check_startup()
+        self.assertEqual(status, doctor.FAIL)
+        self.assertIn("Missing required", message)
+
+
+class TestLogChecks(unittest.TestCase):
+
+    def test_check_logs_missing_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, "nope")
+            status, message, files = doctor.check_logs({"logs": {"path": missing}})
+            self.assertEqual(status, doctor.WARN)
+            self.assertEqual(files, [])
+            self.assertIn(missing, message)
+
+    def test_check_logs_found(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            open(os.path.join(tmp, "error.log"), "w", encoding="utf-8").close()
+            status, _message, files = doctor.check_logs({"logs": {"path": tmp}})
+            self.assertEqual(status, doctor.OK)
+            self.assertEqual(len(files), 1)
+
+    def test_check_log_errors_none_found(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "error.log")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("all quiet\nnothing to see here\n")
+            status, _message = doctor.check_log_errors([path])
+            self.assertEqual(status, doctor.OK)
+
+    def test_check_log_errors_found(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "error.log")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("INFO fine\nERROR kaboom\nCRITICAL also bad\n")
+            status, message = doctor.check_log_errors([path])
+            self.assertEqual(status, doctor.WARN)
+            self.assertIn("2 error-like", message)
+
+    def test_check_log_errors_skipped_when_no_files(self):
+        status, message = doctor.check_log_errors([])
+        self.assertEqual(status, doctor.INFO)
+        self.assertIn("Skipped", message)
+
+    def test_latest_migration_version(self):
+        # Uses the real db/ directory checked into the repo.
+        self.assertEqual(doctor.latest_migration_version("db"), 24)
+
+    def test_latest_migration_version_missing_dir(self):
+        self.assertIsNone(doctor.latest_migration_version("/no/such/dir"))
+
+
+class TestMailCheck(unittest.TestCase):
+
+    def test_mail_check_no_smtp_host(self):
+        with patch.object(doctor, "load_config", return_value={"smtp": {"host": None}}):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = doctor.mail_check("nobody@example.com", color=False)
+            self.assertEqual(rc, 1)
+            self.assertIn("FAIL", buf.getvalue())
+
+    def test_mail_check_send_success(self):
+        cfg = {"smtp": {"host": "smtp.example.com", "port": 587}}
+        with patch.object(doctor, "load_config", return_value=cfg), \
+             patch.object(doctor, "send_email", return_value=True) as send:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = doctor.mail_check("nobody@example.com", color=False)
+            self.assertEqual(rc, 0)
+            self.assertIn("OK", buf.getvalue())
+            send.assert_called_once()
+
+    def test_mail_check_send_raises(self):
+        cfg = {"smtp": {"host": "smtp.example.com", "port": 587}}
+        with patch.object(doctor, "load_config", return_value=cfg), \
+             patch.object(doctor, "send_email", side_effect=OSError("boom")):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = doctor.mail_check("nobody@example.com", color=False)
+            self.assertEqual(rc, 1)
+            self.assertIn("boom", buf.getvalue())
+
+
+class TestDoctorDb(unittest.TestCase):
+    """End-to-end checks that need a real (migrated) database."""
+
+    @use_repository(load_test_data=None)
+    def test_check_database_and_schema_ok(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        try:
+            from hevelius.config import load_config
+            full_config = load_config()
+            status, _message = doctor.check_database(full_config)
+            self.assertEqual(status, doctor.OK)
+
+            schema_status, schema_message = doctor.check_schema(True)
+            self.assertEqual(schema_status, doctor.OK)
+            self.assertIn("up to date", schema_message)
+        finally:
+            os.environ.pop("HEVELIUS_DB_NAME", None)
+
+    @use_repository(load_test_data=None)
+    def test_doctor_end_to_end_returns_failure_on_bad_settings(self, config):
+        os.environ["HEVELIUS_DB_NAME"] = config["database"]
+        # May be set in the ambient test environment (e.g. CI exports
+        # JWT_SECRET_KEY for the API tests); clear them so jwt.secret-key
+        # falls back to the (unset) built-in default and check_jwt() FAILs
+        # deterministically regardless of who else runs in this process.
+        leaky_env = ["JWT_SECRET_KEY", "HEVELIUS_WEB_BASE_URL", "HEVELIUS_SMTP_HOST"]
+        saved = {k: os.environ.pop(k, None) for k in leaky_env}
+        try:
+            args = Namespace(mail_check=None, no_color=True)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = doctor.doctor(args)
+            out = buf.getvalue()
+            self.assertEqual(rc, 1)
+            self.assertIn("Database", out)
+            self.assertIn("DB schema is up to date", out)
+            self.assertIn("JWT secret", out)
+        finally:
+            os.environ.pop("HEVELIUS_DB_NAME", None)
+            for k, v in saved.items():
+                if v is not None:
+                    os.environ[k] = v
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #104.

- Adds `hevelius doctor`, which prints an OK/WARN/FAIL report covering everything the issue asked for:
  - whether the tool can start (core dependency imports)
  - where the config file was loaded from
  - DB credentials / connectivity
  - DB schema version vs. the latest `db/*.psql` migration script
  - presence of the gunicorn access/error logs
  - recent `ERROR`/`CRITICAL`/`Traceback` lines in those logs
  - `jwt.secret-key` set and different from the example placeholder
  - `web.base-url` set and different from the example/default value
  - `smtp.*` configured and looking sane (port range, `from-addr` format, username/password paired)
  - Exits with status 1 if any check fails.
- `hevelius doctor --mail-check EMAIL` sends a real test email through the configured SMTP settings.
- New `logs.path` config section (`HEVELIUS_LOG_PATH` env var, default `/var/log/hevelius`, matching `doc/gunicorn-hevelius.service`) tells `doctor` where to look for logs.
- Documented in `doc/commands.md`, `CHANGELOG.md`, and `README.md`.

While building this, found and fixed two small pre-existing bugs it depends on / exposed:
- `hevelius.config.load_config()` shallow-copied its `DEFAULT_CONFIG` dict, so an env var override (e.g. `JWT_SECRET_KEY`) would permanently leak into every later `load_config()` call in the same process, even after the env var was unset. Fixed with a deep copy.
- `bin/hevelius` never propagated command exit codes (`run()`'s return value was discarded), so `hevelius doctor`'s pass/fail signal (and every other command's) never reached the shell. Fixed with `sys.exit(run())`.

## Test plan

- [x] `python -m pytest -q` — 280 passed (local Postgres 16, `JWT_SECRET_KEY` + `HEVELIUS_DB_PASSWORD` set)
- [x] New `tests/test_cmd_doctor.py` covers each check function in isolation plus DB-backed end-to-end runs via `tests/dbtest.py`
- [x] `flake8 --config .flake8 $(git ls-files '*.py') bin/hevelius` — clean
- [x] `pylint --rcfile .pylint $(git ls-files '*.py') bin/hevelius` — 9.05/10 (unchanged from baseline, well above `fail-under=7.0`)
- [x] Manual runs of `hevelius doctor`, `hevelius doctor --no-color`, and `hevelius doctor --mail-check <email>` against a local DB, both with and without a config file, exercising the OK/WARN/FAIL paths for every check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zAWb6UTa1G1EN7Exy299Y

---
_Generated by [Claude Code](https://claude.ai/code/session_016zAWb6UTa1G1EN7Exy299Y)_