### PR TITLE
Implement OS-2: telescope timezone, project constraints/priority, tasks timestamptz (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
   `projects`/`tasks` gain `priority` (int, default 0); `tasks.skip_before`,
   `skip_after`, `created`, `activated`, `performed` are now `timestamptz` (values
   assumed already UTC).
-- API: telescope create/update/response expose `timezone`. Project create/update/
-  response expose the new observing-constraint columns and `priority`. Task
-  create/update/response expose `priority`.
+- API: telescope create/update/response expose `timezone` (validated as an IANA
+  name). Project create/update/response expose the new observing-constraint
+  columns and `priority`. Task create/update/response expose `priority`.
+  Tasks and projects lists accept `sort_by=priority`; night plan returns tasks
+  ordered by `priority` DESC (then `task_id` DESC).
 - API: `GET`/`PATCH /api/users/me/preferences` for favourite telescope/filter
   and task defaults. Preference row is created lazily on first access.
 - DB: schema bumped to 25: `user_preferences` reworked (one row per user,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 
 ## 0.7.0 (unreleased)
 
+- DB: schema bumped to 26 (OS-2, observation scheduler plan): `telescopes.timezone`
+  (IANA name, default `UTC`; existing rows need the real value backfilled by hand);
+  `projects` gains the same observing-constraint columns `tasks` has (`min_alt`,
+  `moon_distance`, `max_moon_phase`, `max_sun_alt`, `min_interval`, all nullable);
+  `projects`/`tasks` gain `priority` (int, default 0); `tasks.skip_before`,
+  `skip_after`, `created`, `activated`, `performed` are now `timestamptz` (values
+  assumed already UTC).
+- API: telescope create/update/response expose `timezone`. Project create/update/
+  response expose the new observing-constraint columns and `priority`. Task
+  create/update/response expose `priority`.
 - API: `GET`/`PATCH /api/users/me/preferences` for favourite telescope/filter
   and task defaults. Preference row is created lazily on first access.
 - DB: schema bumped to 25: `user_preferences` reworked (one row per user,

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -706,13 +706,11 @@ components:
           nullable: true
           description: Minimum moon distance
         max_moon_phase:
-          type: number
-          format: float
+          type: integer
           nullable: true
           description: Maximum moon phase
         max_sun_alt:
-          type: number
-          format: float
+          type: integer
           nullable: true
           description: Maximum sun altitude
         min_interval:
@@ -815,13 +813,11 @@ components:
           nullable: true
           description: Minimum moon distance
         max_moon_phase:
-          type: number
-          format: float
+          type: integer
           nullable: true
           description: Maximum moon phase
         max_sun_alt:
-          type: number
-          format: float
+          type: integer
           nullable: true
           description: Maximum sun altitude
         min_interval:
@@ -906,13 +902,11 @@ components:
           nullable: true
           description: Minimum moon distance. Send null to clear.
         max_moon_phase:
-          type: number
-          format: float
+          type: integer
           nullable: true
           description: Maximum moon phase. Send null to clear.
         max_sun_alt:
-          type: number
-          format: float
+          type: integer
           nullable: true
           description: Maximum sun altitude. Send null to clear.
         min_interval:
@@ -1019,6 +1013,7 @@ components:
           description: >
             IANA timezone name (e.g. Europe/Warsaw) for this telescope's site, used to
             compute the observing night boundary (local time − 12h). Defaults to UTC.
+            Must be a valid IANA name.
     TelescopesList:
       type: object
       properties:
@@ -1078,7 +1073,8 @@ components:
           default: UTC
           description: >
             IANA timezone name (e.g. Europe/Warsaw) for this telescope's site, used to
-            compute the observing night boundary (local time − 12h).
+            compute the observing night boundary (local time − 12h). Must be a valid
+            IANA name.
     ScopeUpdate:
       type: object
       properties:
@@ -1125,7 +1121,8 @@ components:
           type: string
           description: >
             IANA timezone name (e.g. Europe/Warsaw) for this telescope's site, used to
-            compute the observing night boundary (local time − 12h).
+            compute the observing night boundary (local time − 12h). Must be a valid
+            IANA name.
     ScopeResponse:
       type: object
       properties:
@@ -2253,7 +2250,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [task_id, state, object, exposure, skip_before, skip_after, ra, decl, created, performed, user_id]
+            enum: [task_id, state, object, exposure, skip_before, skip_after, ra, decl, created, performed, user_id, priority]
             default: task_id
         - name: sort_order
           in: query
@@ -2379,7 +2376,7 @@ paths:
                   maximum: 1000
                 sort_by:
                   type: string
-                  enum: [task_id, state, object, exposure, skip_before, skip_after, ra, decl, created, performed, user_id]
+                  enum: [task_id, state, object, exposure, skip_before, skip_after, ra, decl, created, performed, user_id, priority]
                   default: task_id
                 sort_order:
                   type: string
@@ -2659,7 +2656,10 @@ paths:
   /api/night-plan:
     get:
       summary: Get night plan (tasks available for execution)
-      description: Returns tasks that can be executed tonight for a given telescope, optionally filtered by user and date
+      description: >
+        Returns tasks that can be executed tonight for a given telescope,
+        optionally filtered by user and date. Results are ordered by priority
+        descending (higher first), then task_id descending.
       parameters:
         - name: scope_id
           in: query
@@ -2691,7 +2691,10 @@ paths:
         - bearerAuth: []
     post:
       summary: Get night plan (tasks available for execution)
-      description: Returns tasks that can be executed tonight for a given telescope (body parameters)
+      description: >
+        Returns tasks that can be executed tonight for a given telescope (body
+        parameters). Results are ordered by priority descending (higher first),
+        then task_id descending.
       requestBody:
         required: true
         content:
@@ -3144,6 +3147,7 @@ paths:
               - total_integration_time
               - start_date
               - end_date
+              - priority
           description: Sort field for the project list
         - name: sort_order
           in: query

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -162,6 +162,9 @@ components:
           items:
             type: integer
           description: Project IDs this task belongs to
+        priority:
+          type: integer
+          description: Ordering signal for Night Plan / Observation Planning (higher first)
     TasksList:
       type: object
       properties:
@@ -692,6 +695,33 @@ components:
           format: float
           nullable: true
           description: Pixel pitch in Y axis (µm); copied from the telescope's attached sensor at project creation.
+        min_alt:
+          type: number
+          format: float
+          nullable: true
+          description: Minimum altitude
+        moon_distance:
+          type: number
+          format: float
+          nullable: true
+          description: Minimum moon distance
+        max_moon_phase:
+          type: number
+          format: float
+          nullable: true
+          description: Maximum moon phase
+        max_sun_alt:
+          type: number
+          format: float
+          nullable: true
+          description: Maximum sun altitude
+        min_interval:
+          type: integer
+          nullable: true
+          description: Minimum interval between observations
+        priority:
+          type: integer
+          description: Ordering signal for Night Plan / Observation Planning (higher first)
         subframes:
           type: array
           items:
@@ -774,6 +804,34 @@ components:
           format: float
           nullable: true
           description: Pixel pitch Y (µm). Auto-populated from the telescope's sensor when omitted.
+        min_alt:
+          type: number
+          format: float
+          nullable: true
+          description: Minimum altitude
+        moon_distance:
+          type: number
+          format: float
+          nullable: true
+          description: Minimum moon distance
+        max_moon_phase:
+          type: number
+          format: float
+          nullable: true
+          description: Maximum moon phase
+        max_sun_alt:
+          type: number
+          format: float
+          nullable: true
+          description: Maximum sun altitude
+        min_interval:
+          type: integer
+          nullable: true
+          description: Minimum interval between observations
+        priority:
+          type: integer
+          default: 0
+          description: Ordering signal for Night Plan / Observation Planning (higher first)
     ProjectUpdate:
       type: object
       properties:
@@ -837,6 +895,33 @@ components:
           format: float
           nullable: true
           description: Pixel pitch Y (µm). Send null to clear.
+        min_alt:
+          type: number
+          format: float
+          nullable: true
+          description: Minimum altitude. Send null to clear.
+        moon_distance:
+          type: number
+          format: float
+          nullable: true
+          description: Minimum moon distance. Send null to clear.
+        max_moon_phase:
+          type: number
+          format: float
+          nullable: true
+          description: Maximum moon phase. Send null to clear.
+        max_sun_alt:
+          type: number
+          format: float
+          nullable: true
+          description: Maximum sun altitude. Send null to clear.
+        min_interval:
+          type: integer
+          nullable: true
+          description: Minimum interval between observations. Send null to clear.
+        priority:
+          type: integer
+          description: Ordering signal for Night Plan / Observation Planning (higher first)
     ProjectsList:
       type: object
       properties:
@@ -929,6 +1014,11 @@ components:
             Default camera position angle in degrees (0–360, East of North) applied to
             new projects created on this telescope when their rotation is not specified.
             null means no default is set.
+        timezone:
+          type: string
+          description: >
+            IANA timezone name (e.g. Europe/Warsaw) for this telescope's site, used to
+            compute the observing night boundary (local time − 12h). Defaults to UTC.
     TelescopesList:
       type: object
       properties:
@@ -983,6 +1073,12 @@ components:
           description: >
             Default camera position angle in degrees (0–360, East of North) applied to
             new projects created on this telescope when their rotation is not specified.
+        timezone:
+          type: string
+          default: UTC
+          description: >
+            IANA timezone name (e.g. Europe/Warsaw) for this telescope's site, used to
+            compute the observing night boundary (local time − 12h).
     ScopeUpdate:
       type: object
       properties:
@@ -1025,6 +1121,11 @@ components:
           description: >
             Default camera position angle in degrees (0–360, East of North) for new
             projects on this telescope. Send null to clear.
+        timezone:
+          type: string
+          description: >
+            IANA timezone name (e.g. Europe/Warsaw) for this telescope's site, used to
+            compute the observing night boundary (local time − 12h).
     ScopeResponse:
       type: object
       properties:
@@ -2057,6 +2158,10 @@ paths:
                   items:
                     type: integer
                   description: Project IDs this task belongs to (optional; default none)
+                priority:
+                  type: integer
+                  default: 0
+                  description: Ordering signal for Night Plan / Observation Planning (higher first)
             examples:
               basic:
                 summary: Basic new task
@@ -2520,6 +2625,9 @@ paths:
                   items:
                     type: integer
                   description: Project IDs this task belongs to (replaces current list when provided)
+                priority:
+                  type: integer
+                  description: Ordering signal for Night Plan / Observation Planning (higher first)
             examples:
               partial_update:
                 summary: Simple partial update

--- a/db/26-os2-scheduler-data-model.psql
+++ b/db/26-os2-scheduler-data-model.psql
@@ -13,10 +13,12 @@ ALTER TABLE telescopes ADD COLUMN timezone varchar(64) NOT NULL DEFAULT 'UTC';
 -- projects: observing constraints mirroring the columns tasks already has,
 -- so both can go through the same visibility engine (OS-3). Projects
 -- currently have no observing constraints at all.
+-- Types match tasks: min_alt/moon_distance float; max_moon_phase/max_sun_alt int;
+-- min_interval int.
 ALTER TABLE projects ADD COLUMN min_alt float DEFAULT NULL;
 ALTER TABLE projects ADD COLUMN moon_distance float DEFAULT NULL;
-ALTER TABLE projects ADD COLUMN max_moon_phase float DEFAULT NULL;
-ALTER TABLE projects ADD COLUMN max_sun_alt float DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN max_moon_phase int DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN max_sun_alt int DEFAULT NULL;
 ALTER TABLE projects ADD COLUMN min_interval int DEFAULT NULL;
 
 -- priority: ordering signal for Night Plan (OS-4) and Observation Planning

--- a/db/26-os2-scheduler-data-model.psql
+++ b/db/26-os2-scheduler-data-model.psql
@@ -1,0 +1,38 @@
+-- Schema version 26 (OS-2): telescope timezone, project observing constraints
+-- and priority, tasks.priority, tasks timestamp -> timestamptz.
+--
+-- Part of the observation scheduler plan (doc/observation-scheduler-plan.md, OS-2).
+
+-- telescopes.timezone defaults to 'UTC' so the NOT NULL constraint is
+-- satisfiable without guessing at deploy time: the real IANA zone per site
+-- (5-10 rows) can't be reliably derived from lat/lon alone and must be
+-- backfilled by hand after migrating, e.g.:
+--   UPDATE telescopes SET timezone = 'Europe/Madrid' WHERE scope_id = 1;
+ALTER TABLE telescopes ADD COLUMN timezone varchar(64) NOT NULL DEFAULT 'UTC';
+
+-- projects: observing constraints mirroring the columns tasks already has,
+-- so both can go through the same visibility engine (OS-3). Projects
+-- currently have no observing constraints at all.
+ALTER TABLE projects ADD COLUMN min_alt float DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN moon_distance float DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN max_moon_phase float DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN max_sun_alt float DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN min_interval int DEFAULT NULL;
+
+-- priority: ordering signal for Night Plan (OS-4) and Observation Planning
+-- (OS-6/OS-7), also used by the runner's NINA sequence generator (OS-13)
+-- to order target containers.
+ALTER TABLE projects ADD COLUMN priority int NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN priority int NOT NULL DEFAULT 0;
+
+-- tasks: naive timestamps -> timestamptz. These were fine only by
+-- convention (everything writing them happens to use UTC) which is a real
+-- footgun once telescopes span multiple time zones. Values are assumed
+-- already UTC, so this is a type change only, not a value change.
+ALTER TABLE tasks ALTER COLUMN skip_before TYPE timestamptz USING skip_before AT TIME ZONE 'UTC';
+ALTER TABLE tasks ALTER COLUMN skip_after TYPE timestamptz USING skip_after AT TIME ZONE 'UTC';
+ALTER TABLE tasks ALTER COLUMN created TYPE timestamptz USING created AT TIME ZONE 'UTC';
+ALTER TABLE tasks ALTER COLUMN activated TYPE timestamptz USING activated AT TIME ZONE 'UTC';
+ALTER TABLE tasks ALTER COLUMN performed TYPE timestamptz USING performed AT TIME ZONE 'UTC';
+
+UPDATE schema_version SET version = 26;

--- a/doc/db.md
+++ b/doc/db.md
@@ -30,7 +30,7 @@ Part of the observation scheduler plan (`doc/observation-scheduler-plan.md`, OS-
   value must be backfilled by hand afterwards (5–10 rows, not reliably derivable from
   `lat`/`lon` alone).
 - **projects** – Added the same observing-constraint columns `tasks` already has, all
-  nullable: **min_alt**, **moon_distance**, **max_moon_phase**, **max_sun_alt** (float),
+  nullable: **min_alt**, **moon_distance** (float); **max_moon_phase**, **max_sun_alt**,
   **min_interval** (int). Projects previously had no observing constraints at all.
 - **projects**, **tasks** – Added **priority** (int, NOT NULL, default 0): ordering
   signal for Night Plan and Observation Planning.

--- a/doc/db.md
+++ b/doc/db.md
@@ -20,6 +20,24 @@ python bin/hevelius migrate
 
 he_solved_ra - Right Ascension, from the plate solving, in degrees (0-359)
 
+### Schema version 26 (OS-2: telescope timezone, project constraints, priority)
+
+Part of the observation scheduler plan (`doc/observation-scheduler-plan.md`, OS-2).
+
+- **telescopes** – Added **timezone** (varchar 64, NOT NULL, default `'UTC'`): IANA
+  timezone name (e.g. `Europe/Warsaw`) used to compute the observing night boundary
+  (local time − 12h). Existing rows default to `UTC` on migration; the real per-site
+  value must be backfilled by hand afterwards (5–10 rows, not reliably derivable from
+  `lat`/`lon` alone).
+- **projects** – Added the same observing-constraint columns `tasks` already has, all
+  nullable: **min_alt**, **moon_distance**, **max_moon_phase**, **max_sun_alt** (float),
+  **min_interval** (int). Projects previously had no observing constraints at all.
+- **projects**, **tasks** – Added **priority** (int, NOT NULL, default 0): ordering
+  signal for Night Plan and Observation Planning.
+- **tasks** – **skip_before**, **skip_after**, **created**, **activated**, **performed**
+  changed from naive `timestamp` to `timestamptz`. Existing values are assumed already
+  UTC (the prior convention), so this is a type change only, not a value change.
+
 ### Schema version 24 (asteroid tags + proper names)
 
 - **asteroids** – Added optional **name** (varchar 64): proper name parsed from the

--- a/hevelius/api/routes/projects.py
+++ b/hevelius/api/routes/projects.py
@@ -29,13 +29,15 @@ logger = logging.getLogger(__name__)
 _PROJECT_SELECT_COLS = (
     "project_id, name, description, regexps, scope_id, ra, decl, active, "
     "last_updated, total_integration_time, start_date, end_date, publications, rotation, "
-    "focal, resx, resy, pixel_x, pixel_y"
+    "focal, resx, resy, pixel_x, pixel_y, "
+    "min_alt, moon_distance, max_moon_phase, max_sun_alt, min_interval, priority"
 )
 
 _PROJECT_SELECT_COLS_P = (
     "p.project_id, p.name, p.description, p.regexps, p.scope_id, p.ra, p.decl, p.active, "
     "p.last_updated, p.total_integration_time, p.start_date, p.end_date, p.publications, p.rotation, "
-    "p.focal, p.resx, p.resy, p.pixel_x, p.pixel_y"
+    "p.focal, p.resx, p.resy, p.pixel_x, p.pixel_y, "
+    "p.min_alt, p.moon_distance, p.max_moon_phase, p.max_sun_alt, p.min_interval, p.priority"
 )
 
 _PROJECT_SORT_COLUMNS = {
@@ -90,6 +92,8 @@ def _project_row_to_dict(r, subframes=None, user_ids=None):
         "publications": _normalize_publications(r[12]),
         "rotation": r[13],
         "focal": r[14], "resx": r[15], "resy": r[16], "pixel_x": r[17], "pixel_y": r[18],
+        "min_alt": r[19], "moon_distance": r[20], "max_moon_phase": r[21], "max_sun_alt": r[22],
+        "min_interval": r[23], "priority": r[24],
         "subframes": subframes or [], "user_ids": user_ids or []
     }
 
@@ -200,6 +204,12 @@ class ProjectsResource(MethodView):
         resy = body.get("resy")
         pixel_x = body.get("pixel_x")
         pixel_y = body.get("pixel_y")
+        min_alt = body.get("min_alt")
+        moon_distance = body.get("moon_distance")
+        max_moon_phase = body.get("max_moon_phase")
+        max_sun_alt = body.get("max_sun_alt")
+        min_interval = body.get("min_interval")
+        priority = body.get("priority", 0)
         cnx = db.connect()
         if ra is None or decl is None:
             cat = db.run_query(cnx, "SELECT object_id, name, ra, decl FROM objects WHERE lower(name)=%s", (name.strip().lower(),))
@@ -238,10 +248,12 @@ class ProjectsResource(MethodView):
         db.run_query(
             cnx,
             "INSERT INTO projects (name, description, regexps, scope_id, ra, decl, active, start_date, end_date, "
-            "publications, rotation, focal, resx, resy, pixel_x, pixel_y) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            "publications, rotation, focal, resx, resy, pixel_x, pixel_y, "
+            "min_alt, moon_distance, max_moon_phase, max_sun_alt, min_interval, priority) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
             (name, description, regexps, scope_id, ra, decl, active, start_date, end_date,
-             publications, rotation, focal, resx, resy, pixel_x, pixel_y),
+             publications, rotation, focal, resx, resy, pixel_x, pixel_y,
+             min_alt, moon_distance, max_moon_phase, max_sun_alt, min_interval, priority),
         )
         row = db.run_query(
             cnx,
@@ -331,10 +343,14 @@ class ProjectDetailResource(MethodView):
         if "rotation" in body:
             updates.append("rotation = %s")
             args.append(body["rotation"])   # None is valid — clears the value
-        for key in ("focal", "resx", "resy", "pixel_x", "pixel_y"):
+        for key in ("focal", "resx", "resy", "pixel_x", "pixel_y",
+                    "min_alt", "moon_distance", "max_moon_phase", "max_sun_alt", "min_interval"):
             if key in body:
                 updates.append(f"{key} = %s")
-                args.append(body[key])
+                args.append(body[key])   # None is valid for nullable fields — clears the value
+        if "priority" in body and body["priority"] is not None:
+            updates.append("priority = %s")
+            args.append(body["priority"])
         if updates:
             args.append(project_id)
             db.run_query(cnx, "UPDATE projects SET " + ", ".join(updates) + " WHERE project_id = %s", tuple(args))

--- a/hevelius/api/routes/projects.py
+++ b/hevelius/api/routes/projects.py
@@ -47,6 +47,7 @@ _PROJECT_SORT_COLUMNS = {
     "total_integration_time": "p.total_integration_time",
     "start_date": "p.start_date",
     "end_date": "p.end_date",
+    "priority": "p.priority",
 }
 
 

--- a/hevelius/api/routes/scopes.py
+++ b/hevelius/api/routes/scopes.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def _scopes_base_query():
     return """
         SELECT t.scope_id, t.name, t.descr, t.min_dec, t.max_dec, t.focal, t.aperture,
-               t.lon, t.lat, t.alt, t.sensor_id, t.active, t.default_rotation,
+               t.lon, t.lat, t.alt, t.sensor_id, t.active, t.default_rotation, t.timezone,
                s.sensor_id, s.name, s.resx, s.resy, s.pixel_x, s.pixel_y,
                s.bits, s.width, s.height, s.vendor, s.url, s.active AS sensor_active
         FROM telescopes t
@@ -98,7 +98,8 @@ class ScopesResource(MethodView):
                 return {"status": False, "scope_id": None, "scope": None, "msg": f"Telescope scope_id={scope_id} already exists"}
         cols = ["scope_id", "name"]
         vals = [scope_id, name]
-        for key in ("descr", "min_dec", "max_dec", "focal", "aperture", "lon", "lat", "alt", "active", "default_rotation"):
+        for key in ("descr", "min_dec", "max_dec", "focal", "aperture", "lon", "lat", "alt", "active",
+                    "default_rotation", "timezone"):
             if data.get(key) is not None:
                 cols.append(key)
                 vals.append(data[key])
@@ -118,7 +119,8 @@ class ScopesResource(MethodView):
             "scope_id": scope_id, "name": name, "descr": data.get("descr"), "min_dec": data.get("min_dec"),
             "max_dec": data.get("max_dec"), "focal": data.get("focal"), "aperture": data.get("aperture"),
             "lon": data.get("lon"), "lat": data.get("lat"), "alt": data.get("alt"), "sensor": None,
-            "filters": [], "active": data.get("active", True), "default_rotation": data.get("default_rotation")
+            "filters": [], "active": data.get("active", True), "default_rotation": data.get("default_rotation"),
+            "timezone": data.get("timezone", "UTC")
         }
         return {"status": True, "scope_id": scope_id, "scope": scope, "msg": "Created"}
 
@@ -151,7 +153,8 @@ class ScopeDetailResource(MethodView):
             return {"status": False, "scope": None, "msg": f"Telescope scope_id={scope_id} not found"}
         updates = []
         params = []
-        for key in ("name", "descr", "min_dec", "max_dec", "focal", "aperture", "lon", "lat", "alt", "active"):
+        for key in ("name", "descr", "min_dec", "max_dec", "focal", "aperture", "lon", "lat", "alt", "active",
+                    "timezone"):
             if data.get(key) is not None:
                 updates.append(f"{key} = %s")
                 params.append(data[key])
@@ -226,14 +229,15 @@ def _telescope_row_to_dict(row, filters_list=None):
         'alt': row[9],
         'active': row[11],
         'default_rotation': row[12],
+        'timezone': row[13],
         'filters': filters_list or []
     }
     if row[10] is not None:  # sensor_id
         telescope['sensor'] = {
-            'sensor_id': row[13], 'name': row[14], 'resx': row[15], 'resy': row[16],
-            'pixel_x': row[17], 'pixel_y': row[18], 'bits': row[19],
-            'width': row[20], 'height': row[21],
-            'vendor': row[22], 'url': row[23], 'active': row[24]
+            'sensor_id': row[14], 'name': row[15], 'resx': row[16], 'resy': row[17],
+            'pixel_x': row[18], 'pixel_y': row[19], 'bits': row[20],
+            'width': row[21], 'height': row[22],
+            'vendor': row[23], 'url': row[24], 'active': row[25]
         }
     else:
         telescope['sensor'] = None

--- a/hevelius/api/routes/tasks.py
+++ b/hevelius/api/routes/tasks.py
@@ -270,6 +270,7 @@ class TasksResource(MethodView):
             'created': 'tasks.created',
             'performed': 'tasks.performed',
             'user_id': 'tasks.user_id',
+            'priority': 'tasks.priority',
         }
         sort_field_sql = sort_field_map.get(sort_field, 'tasks.task_id')
         sort_order = args.get('sort_order', 'desc').upper()
@@ -627,7 +628,7 @@ class NightPlanResource(MethodView):
             query += " AND tasks.user_id = %s"
             values.append(user_id)
 
-        query += " ORDER BY task_id DESC"
+        query += " ORDER BY priority DESC, task_id DESC"
 
         cnx = db.connect()
         tasks_list = db.run_query(cnx, query, values)

--- a/hevelius/api/routes/tasks.py
+++ b/hevelius/api/routes/tasks.py
@@ -182,7 +182,8 @@ class TasksResource(MethodView):
             tasks.min_alt, tasks.moon_distance, tasks.skip_before, tasks.skip_after,
             tasks.min_interval, tasks.comment, tasks.state, tasks.imagename,
             tasks.created, tasks.activated, tasks.performed, tasks.max_moon_phase,
-            tasks.max_sun_alt, tasks.auto_center, tasks.calibrated, tasks.solved, tasks.sent
+            tasks.max_sun_alt, tasks.auto_center, tasks.calibrated, tasks.solved, tasks.sent,
+            tasks.priority
             FROM tasks
             JOIN users ON tasks.user_id = users.user_id
             LEFT JOIN telescopes ON tasks.scope_id = telescopes.scope_id
@@ -340,6 +341,7 @@ class TasksResource(MethodView):
                 'calibrated': bool(task[32]),
                 'solved': bool(task[33]),
                 'sent': bool(task[34]),
+                'priority': task[35],
                 'project_ids': sorted(project_ids_by_task.get(task[0], []))
             }
             formatted_tasks.append(task_dict)
@@ -432,7 +434,7 @@ class TaskGetResource(MethodView):
             min_interval, comment, state, imagename,
             created, activated, performed, max_moon_phase,
             max_sun_alt, auto_center, calibrated, solved,
-            sent, scope_id FROM tasks, users WHERE tasks.user_id = users.user_id AND task_id = %s"""
+            sent, scope_id, priority FROM tasks, users WHERE tasks.user_id = users.user_id AND task_id = %s"""
 
         cnx = db.connect()
         task = db.run_query(cnx, query, (task_id,))
@@ -485,6 +487,7 @@ class TaskGetResource(MethodView):
             'solved': bool(task[30]),
             'sent': bool(task[31]),
             'scope_id': task[32],
+            'priority': task[33],
             'project_ids': project_ids
         }
 
@@ -604,7 +607,7 @@ class NightPlanResource(MethodView):
             min_interval, comment, state, imagename,
             created, activated, performed, max_moon_phase,
             max_sun_alt, auto_center, calibrated, solved,
-            sent FROM tasks, users
+            sent, priority FROM tasks, users
             WHERE tasks.user_id = users.user_id
             AND scope_id = %s
             AND state IN (1, 2, 3)"""
@@ -666,7 +669,8 @@ class NightPlanResource(MethodView):
                 'auto_center': bool(task[29]),
                 'calibrated': bool(task[30]),
                 'solved': bool(task[31]),
-                'sent': bool(task[32])
+                'sent': bool(task[32]),
+                'priority': task[33]
             }
             formatted_tasks.append(task_dict)
 

--- a/hevelius/api/schemas/__init__.py
+++ b/hevelius/api/schemas/__init__.py
@@ -1,7 +1,16 @@
 """Marshmallow request/response schemas for the Hevelius REST API."""
 from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from marshmallow import Schema, fields, ValidationError, validate, validates_schema
+
+
+def _validate_iana_timezone(value):
+    """Reject strings that are not valid IANA timezone names."""
+    try:
+        ZoneInfo(value)
+    except (ZoneInfoNotFoundError, KeyError, ValueError) as exc:
+        raise ValidationError(f"Invalid IANA timezone name: {value!r}") from exc
 
 
 class LoginRequestSchema(Schema):
@@ -162,7 +171,7 @@ class TaskSortField(fields.String):
         allowed_fields = [
             'task_id', 'state', 'object', 'exposure',
             'skip_before', 'skip_after', 'ra', 'decl',
-            'created', 'performed', 'user_id'
+            'created', 'performed', 'user_id', 'priority'
         ]
         if value not in allowed_fields:
             raise ValidationError(f"Invalid sort field. Must be one of: {', '.join(allowed_fields)}")
@@ -501,7 +510,8 @@ class ScopeCreateSchema(Schema):
         metadata={"description": "Default camera rotation (degrees East of North) for new projects on this telescope"}
     )
     timezone = fields.String(
-        load_default="UTC", validate=validate.Length(max=64),
+        load_default="UTC",
+        validate=[validate.Length(max=64), _validate_iana_timezone],
         metadata={"description": "IANA timezone name (e.g. Europe/Warsaw) used to compute the observing night boundary"}
     )
 
@@ -519,7 +529,9 @@ class ScopeUpdateSchema(Schema):
     sensor_id = fields.Integer(load_default=None)
     active = fields.Boolean()
     default_rotation = fields.Float(allow_none=True)
-    timezone = fields.String(validate=validate.Length(max=64))
+    timezone = fields.String(
+        validate=[validate.Length(max=64), _validate_iana_timezone],
+    )
 
 
 class ProjectSubframeSchema(Schema):
@@ -556,8 +568,8 @@ class ProjectSchema(Schema):
     pixel_y = fields.Float(allow_none=True, metadata={"description": "Pixel pitch Y (µm)"})
     min_alt = fields.Float(allow_none=True, metadata={"description": "Minimum altitude"})
     moon_distance = fields.Float(allow_none=True, metadata={"description": "Minimum moon distance"})
-    max_moon_phase = fields.Float(allow_none=True, metadata={"description": "Maximum moon phase"})
-    max_sun_alt = fields.Float(allow_none=True, metadata={"description": "Maximum sun altitude"})
+    max_moon_phase = fields.Integer(allow_none=True, metadata={"description": "Maximum moon phase"})
+    max_sun_alt = fields.Integer(allow_none=True, metadata={"description": "Maximum sun altitude"})
     min_interval = fields.Integer(allow_none=True, metadata={"description": "Minimum interval between observations"})
     priority = fields.Integer(metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"})
     subframes = fields.List(fields.Nested(ProjectSubframeSchema))
@@ -583,8 +595,8 @@ class ProjectCreateSchema(Schema):
     pixel_y = fields.Float(load_default=None, allow_none=True)
     min_alt = fields.Float(load_default=None, allow_none=True, metadata={"description": "Minimum altitude"})
     moon_distance = fields.Float(load_default=None, allow_none=True, metadata={"description": "Minimum moon distance"})
-    max_moon_phase = fields.Float(load_default=None, allow_none=True, metadata={"description": "Maximum moon phase"})
-    max_sun_alt = fields.Float(load_default=None, allow_none=True, metadata={"description": "Maximum sun altitude"})
+    max_moon_phase = fields.Integer(load_default=None, allow_none=True, metadata={"description": "Maximum moon phase"})
+    max_sun_alt = fields.Integer(load_default=None, allow_none=True, metadata={"description": "Maximum sun altitude"})
     min_interval = fields.Integer(load_default=None, allow_none=True, metadata={"description": "Minimum interval between observations"})
     priority = fields.Integer(
         load_default=0,
@@ -611,8 +623,8 @@ class ProjectUpdateSchema(Schema):
     pixel_y = fields.Float(allow_none=True)
     min_alt = fields.Float(allow_none=True, metadata={"description": "Minimum altitude. Send null to clear."})
     moon_distance = fields.Float(allow_none=True, metadata={"description": "Minimum moon distance. Send null to clear."})
-    max_moon_phase = fields.Float(allow_none=True, metadata={"description": "Maximum moon phase. Send null to clear."})
-    max_sun_alt = fields.Float(allow_none=True, metadata={"description": "Maximum sun altitude. Send null to clear."})
+    max_moon_phase = fields.Integer(allow_none=True, metadata={"description": "Maximum moon phase. Send null to clear."})
+    max_sun_alt = fields.Integer(allow_none=True, metadata={"description": "Maximum sun altitude. Send null to clear."})
     min_interval = fields.Integer(allow_none=True, metadata={"description": "Minimum interval between observations. Send null to clear."})
     priority = fields.Integer(metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"})
 

--- a/hevelius/api/schemas/__init__.py
+++ b/hevelius/api/schemas/__init__.py
@@ -128,6 +128,10 @@ class TaskAddRequestSchema(Schema):
         load_default=lambda: [],
         metadata={"description": "Project IDs this task belongs to (default: none)"}
     )
+    priority = fields.Integer(
+        load_default=0,
+        metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"}
+    )
 
     @validates_schema
     def validate_cross_fields(self, data, **_kwargs):
@@ -230,6 +234,7 @@ class Task(Schema):
     solved = fields.Boolean(metadata={"description": "Plate solving status"})
     sent = fields.Boolean(metadata={"description": "Sent status"})
     project_ids = fields.List(fields.Integer(), metadata={"description": "Project IDs this task belongs to"})
+    priority = fields.Integer(metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"})
 
 
 class TasksList(Schema):
@@ -362,6 +367,9 @@ class TaskUpdateRequestSchema(Schema):
         fields.Integer(),
         metadata={"description": "Project IDs this task belongs to (replaces current list when provided)"}
     )
+    priority = fields.Integer(
+        metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"}
+    )
 
     @validates_schema
     def validate_cross_fields(self, data, **_kwargs):
@@ -466,6 +474,9 @@ class TelescopeSchema(Schema):
         allow_none=True,
         metadata={"description": "Default camera rotation (degrees East of North) applied to new projects on this telescope when not specified"}
     )
+    timezone = fields.String(
+        metadata={"description": "IANA timezone name (e.g. Europe/Warsaw) used to compute the observing night boundary"}
+    )
 
 
 class TelescopesListSchema(Schema):
@@ -489,6 +500,10 @@ class ScopeCreateSchema(Schema):
         load_default=None, allow_none=True,
         metadata={"description": "Default camera rotation (degrees East of North) for new projects on this telescope"}
     )
+    timezone = fields.String(
+        load_default="UTC", validate=validate.Length(max=64),
+        metadata={"description": "IANA timezone name (e.g. Europe/Warsaw) used to compute the observing night boundary"}
+    )
 
 
 class ScopeUpdateSchema(Schema):
@@ -504,6 +519,7 @@ class ScopeUpdateSchema(Schema):
     sensor_id = fields.Integer(load_default=None)
     active = fields.Boolean()
     default_rotation = fields.Float(allow_none=True)
+    timezone = fields.String(validate=validate.Length(max=64))
 
 
 class ProjectSubframeSchema(Schema):
@@ -538,6 +554,12 @@ class ProjectSchema(Schema):
     resy = fields.Integer(allow_none=True, metadata={"description": "Sensor height (pixels)"})
     pixel_x = fields.Float(allow_none=True, metadata={"description": "Pixel pitch X (µm)"})
     pixel_y = fields.Float(allow_none=True, metadata={"description": "Pixel pitch Y (µm)"})
+    min_alt = fields.Float(allow_none=True, metadata={"description": "Minimum altitude"})
+    moon_distance = fields.Float(allow_none=True, metadata={"description": "Minimum moon distance"})
+    max_moon_phase = fields.Float(allow_none=True, metadata={"description": "Maximum moon phase"})
+    max_sun_alt = fields.Float(allow_none=True, metadata={"description": "Maximum sun altitude"})
+    min_interval = fields.Integer(allow_none=True, metadata={"description": "Minimum interval between observations"})
+    priority = fields.Integer(metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"})
     subframes = fields.List(fields.Nested(ProjectSubframeSchema))
     user_ids = fields.List(fields.Integer())
 
@@ -559,6 +581,15 @@ class ProjectCreateSchema(Schema):
     resy = fields.Integer(load_default=None, allow_none=True)
     pixel_x = fields.Float(load_default=None, allow_none=True)
     pixel_y = fields.Float(load_default=None, allow_none=True)
+    min_alt = fields.Float(load_default=None, allow_none=True, metadata={"description": "Minimum altitude"})
+    moon_distance = fields.Float(load_default=None, allow_none=True, metadata={"description": "Minimum moon distance"})
+    max_moon_phase = fields.Float(load_default=None, allow_none=True, metadata={"description": "Maximum moon phase"})
+    max_sun_alt = fields.Float(load_default=None, allow_none=True, metadata={"description": "Maximum sun altitude"})
+    min_interval = fields.Integer(load_default=None, allow_none=True, metadata={"description": "Minimum interval between observations"})
+    priority = fields.Integer(
+        load_default=0,
+        metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"}
+    )
 
 
 class ProjectUpdateSchema(Schema):
@@ -578,6 +609,12 @@ class ProjectUpdateSchema(Schema):
     resy = fields.Integer(allow_none=True)
     pixel_x = fields.Float(allow_none=True)
     pixel_y = fields.Float(allow_none=True)
+    min_alt = fields.Float(allow_none=True, metadata={"description": "Minimum altitude. Send null to clear."})
+    moon_distance = fields.Float(allow_none=True, metadata={"description": "Minimum moon distance. Send null to clear."})
+    max_moon_phase = fields.Float(allow_none=True, metadata={"description": "Maximum moon phase. Send null to clear."})
+    max_sun_alt = fields.Float(allow_none=True, metadata={"description": "Maximum sun altitude. Send null to clear."})
+    min_interval = fields.Integer(allow_none=True, metadata={"description": "Minimum interval between observations. Send null to clear."})
+    priority = fields.Integer(metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"})
 
 
 class ProjectSubframeCreateSchema(Schema):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -97,6 +97,30 @@ class TestTaskAdd(unittest.TestCase):
 
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    @use_repository
+    def test_task_add_priority_defaults_to_zero(self, config):
+        """Task added without priority defaults to 0."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        test_task = {"user_id": 1, "scope_id": 1, "object": "M31", "ra": 0.712, "decl": 41.27}
+        response = self.app.post('/api/task-add', data=json.dumps(test_task), headers=self.headers)
+        task_id = json.loads(response.data)['task_id']
+        response = self.app.get(f'/api/task-get?task_id={task_id}', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(data['task']['priority'], 0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_task_add_with_priority(self, config):
+        """Task added with an explicit priority persists it."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        test_task = {"user_id": 1, "scope_id": 1, "object": "M31", "ra": 0.712, "decl": 41.27, "priority": 7}
+        response = self.app.post('/api/task-add', data=json.dumps(test_task), headers=self.headers)
+        task_id = json.loads(response.data)['task_id']
+        response = self.app.get(f'/api/task-get?task_id={task_id}', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(data['task']['priority'], 7)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
     def test_task_add_missing_required(self):
         """Test task addition with missing required fields"""
         test_task = {
@@ -416,6 +440,26 @@ class TestTaskUpdate(unittest.TestCase):
         self.assertEqual(data['task']['decl'], 41.27)
         self.assertEqual(data['task']['scope_id'], 2)  # Verify scope_id was updated
 
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_task_update_sets_priority(self, config):
+        """Update task priority via task-update."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        test_task = {"user_id": 1, "scope_id": 1, "object": "M31", "ra": 0.712, "decl": 41.27}
+        response = self.app.post('/api/task-add', data=json.dumps(test_task), headers=self.headers)
+        task_id = json.loads(response.data)['task_id']
+
+        response = self.app.post(
+            '/api/task-update',
+            data=json.dumps({"task_id": task_id, "priority": 9}),
+            headers=self.headers
+        )
+        self.assertTrue(json.loads(response.data)['status'])
+
+        response = self.app.get(f'/api/task-get?task_id={task_id}', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(data['task']['priority'], 9)
         os.environ.pop('HEVELIUS_DB_NAME')
 
     @use_repository
@@ -838,6 +882,25 @@ class TestTasks(unittest.TestCase):
                 'Authorization': f'Bearer {self.test_token}',
                 'Content-Type': 'application/json'
             }
+
+    @use_repository(load_test_data="tests/test-data-basic.psql")
+    def test_tasks_list_includes_priority(self, config):
+        """GET /api/tasks returns the priority field for each task."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.post(
+            '/api/task-add',
+            data=json.dumps({"user_id": 1, "scope_id": 1, "object": "M31", "ra": 0.712, "decl": 41.27, "priority": 4}),
+            headers=self.headers
+        )
+        self.assertTrue(json.loads(response.data)['status'])
+
+        response = self.app.get('/api/tasks', headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data['tasks'])
+        task = next(t for t in data['tasks'] if t['object'] == 'M31')
+        self.assertEqual(task['priority'], 4)
+        os.environ.pop('HEVELIUS_DB_NAME')
 
     @use_repository(load_test_data="tests/test-data-basic.psql")
     def test_tasks_pagination(self, config):
@@ -1792,6 +1855,44 @@ class TestTelescopeOperations(unittest.TestCase):
         self.assertIsNone(data['scope']['default_rotation'])
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    # ── timezone field tests (OS-2) ─────────────────────────────────────────
+
+    @use_repository
+    def test_telescope_post_add_default_timezone_is_utc(self, config):
+        """Add telescope without timezone; defaults to UTC."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {"name": "No Timezone Scope"}
+        response = self.app.post('/api/scopes', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['scope']['timezone'], 'UTC')
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_telescope_post_add_with_timezone(self, config):
+        """Add telescope with an explicit IANA timezone."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {"name": "Nerpio Scope", "timezone": "Europe/Madrid"}
+        response = self.app.post('/api/scopes', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['scope']['timezone'], 'Europe/Madrid')
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_telescope_patch_sets_timezone(self, config):
+        """PATCH telescope to set timezone."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.patch(
+            '/api/scopes/1',
+            data=json.dumps({"timezone": "America/Santiago"}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['scope']['timezone'], 'America/Santiago')
+        os.environ.pop('HEVELIUS_DB_NAME')
+
 
 class TestProjectOperations(unittest.TestCase):
     """Tests for project and subframe CRUD: add (catalog lookup), edit, subframe add/edit/remove."""
@@ -1878,6 +1979,71 @@ class TestProjectOperations(unittest.TestCase):
         self.assertTrue(data['status'])
         self.assertEqual(data['project']['name'], 'Updated Z Peg')
         self.assertEqual(data['project']['description'], 'Updated desc')
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    # ── observing constraints + priority fields (OS-2) ──────────────────────
+
+    @use_repository
+    def test_project_create_with_constraints_and_priority(self, config):
+        """Create project with observing constraints and priority set."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {
+            "name": "Constrained Project", "scope_id": 1, "ra": 0.5, "decl": 25.0,
+            "min_alt": 30.0, "moon_distance": 45.0, "max_moon_phase": 0.5,
+            "max_sun_alt": -12.0, "min_interval": 3600, "priority": 5,
+        }
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(data['project']['min_alt'], 30.0)
+        self.assertEqual(data['project']['moon_distance'], 45.0)
+        self.assertEqual(data['project']['max_moon_phase'], 0.5)
+        self.assertEqual(data['project']['max_sun_alt'], -12.0)
+        self.assertEqual(data['project']['min_interval'], 3600)
+        self.assertEqual(data['project']['priority'], 5)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_create_without_constraints_defaults(self, config):
+        """Create project without constraints; constraints are null, priority defaults to 0."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        body = {"name": "Unconstrained Project", "scope_id": 1, "ra": 0.5, "decl": 25.0}
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 201)
+        self.assertIsNone(data['project']['min_alt'])
+        self.assertIsNone(data['project']['moon_distance'])
+        self.assertIsNone(data['project']['max_moon_phase'])
+        self.assertIsNone(data['project']['max_sun_alt'])
+        self.assertIsNone(data['project']['min_interval'])
+        self.assertEqual(data['project']['priority'], 0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_patch_sets_and_clears_constraints(self, config):
+        """PATCH project to set observing constraints and priority, then clear the nullable ones."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.patch(
+            '/api/projects/1',
+            data=json.dumps({"min_alt": 25.0, "max_sun_alt": -10.0, "priority": 3}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['project']['min_alt'], 25.0)
+        self.assertEqual(data['project']['max_sun_alt'], -10.0)
+        self.assertEqual(data['project']['priority'], 3)
+
+        response = self.app.patch(
+            '/api/projects/1',
+            data=json.dumps({"min_alt": None}),
+            headers=self.headers
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(data['project']['min_alt'])
+        # priority (NOT NULL) is unaffected by the previous request
+        self.assertEqual(data['project']['priority'], 3)
         os.environ.pop('HEVELIUS_DB_NAME')
 
     @use_repository

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -862,6 +862,31 @@ class TestNightPlan(unittest.TestCase):
 
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    @use_repository(load_test_data="tests/test-data-basic.psql")
+    def test_night_plan_orders_by_priority_desc(self, config):
+        """Night plan returns higher-priority tasks first."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        for priority, obj in ((1, 'LowPri'), (9, 'HighPri'), (5, 'MidPri')):
+            response = self.app.post(
+                '/api/task-add',
+                data=json.dumps({
+                    "user_id": 1, "scope_id": 1, "object": obj,
+                    "ra": 0.1, "decl": 10.0, "priority": priority, "state": 1,
+                }),
+                headers=self.headers,
+            )
+            self.assertTrue(json.loads(response.data)['status'])
+
+        response = self.app.get(
+            '/api/night-plan?scope_id=1&user_id=1',
+            headers=self.headers,
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        names = [t['object'] for t in data['tasks'] if t['object'] in ('LowPri', 'HighPri', 'MidPri')]
+        self.assertEqual(names, ['HighPri', 'MidPri', 'LowPri'])
+        os.environ.pop('HEVELIUS_DB_NAME')
+
 
 class TestTasks(unittest.TestCase):
     def setUp(self):
@@ -900,6 +925,39 @@ class TestTasks(unittest.TestCase):
         self.assertTrue(data['tasks'])
         task = next(t for t in data['tasks'] if t['object'] == 'M31')
         self.assertEqual(task['priority'], 4)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository(load_test_data="tests/test-data-basic.psql")
+    def test_tasks_sort_by_priority(self, config):
+        """GET /api/tasks?sort_by=priority orders by priority."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        for priority, obj in ((1, 'P1'), (7, 'P7'), (3, 'P3')):
+            response = self.app.post(
+                '/api/task-add',
+                data=json.dumps({
+                    "user_id": 1, "scope_id": 1, "object": obj,
+                    "ra": 0.1, "decl": 10.0, "priority": priority,
+                }),
+                headers=self.headers,
+            )
+            self.assertTrue(json.loads(response.data)['status'])
+
+        response = self.app.get(
+            '/api/tasks?sort_by=priority&sort_order=desc&per_page=100',
+            headers=self.headers,
+        )
+        data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        ours = [t for t in data['tasks'] if t['object'] in ('P1', 'P7', 'P3')]
+        self.assertEqual([t['object'] for t in ours], ['P7', 'P3', 'P1'])
+
+        response = self.app.get(
+            '/api/tasks?sort_by=priority&sort_order=asc&per_page=100',
+            headers=self.headers,
+        )
+        data = json.loads(response.data)
+        ours = [t for t in data['tasks'] if t['object'] in ('P1', 'P7', 'P3')]
+        self.assertEqual([t['object'] for t in ours], ['P1', 'P3', 'P7'])
         os.environ.pop('HEVELIUS_DB_NAME')
 
     @use_repository(load_test_data="tests/test-data-basic.psql")
@@ -1893,6 +1951,25 @@ class TestTelescopeOperations(unittest.TestCase):
         self.assertEqual(data['scope']['timezone'], 'America/Santiago')
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    @use_repository
+    def test_telescope_rejects_invalid_timezone(self, config):
+        """Create/update with a non-IANA timezone name fails validation."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        response = self.app.post(
+            '/api/scopes',
+            data=json.dumps({"name": "Bad TZ", "timezone": "Not/AZone"}),
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 422)
+
+        response = self.app.patch(
+            '/api/scopes/1',
+            data=json.dumps({"timezone": "Also/Fake"}),
+            headers=self.headers,
+        )
+        self.assertEqual(response.status_code, 422)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
 
 class TestProjectOperations(unittest.TestCase):
     """Tests for project and subframe CRUD: add (catalog lookup), edit, subframe add/edit/remove."""
@@ -1989,16 +2066,16 @@ class TestProjectOperations(unittest.TestCase):
         os.environ['HEVELIUS_DB_NAME'] = config['database']
         body = {
             "name": "Constrained Project", "scope_id": 1, "ra": 0.5, "decl": 25.0,
-            "min_alt": 30.0, "moon_distance": 45.0, "max_moon_phase": 0.5,
-            "max_sun_alt": -12.0, "min_interval": 3600, "priority": 5,
+            "min_alt": 30.0, "moon_distance": 45.0, "max_moon_phase": 50,
+            "max_sun_alt": -12, "min_interval": 3600, "priority": 5,
         }
         response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(data['project']['min_alt'], 30.0)
         self.assertEqual(data['project']['moon_distance'], 45.0)
-        self.assertEqual(data['project']['max_moon_phase'], 0.5)
-        self.assertEqual(data['project']['max_sun_alt'], -12.0)
+        self.assertEqual(data['project']['max_moon_phase'], 50)
+        self.assertEqual(data['project']['max_sun_alt'], -12)
         self.assertEqual(data['project']['min_interval'], 3600)
         self.assertEqual(data['project']['priority'], 5)
         os.environ.pop('HEVELIUS_DB_NAME')
@@ -2025,13 +2102,13 @@ class TestProjectOperations(unittest.TestCase):
         os.environ['HEVELIUS_DB_NAME'] = config['database']
         response = self.app.patch(
             '/api/projects/1',
-            data=json.dumps({"min_alt": 25.0, "max_sun_alt": -10.0, "priority": 3}),
+            data=json.dumps({"min_alt": 25.0, "max_sun_alt": -10, "priority": 3}),
             headers=self.headers
         )
         data = json.loads(response.data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data['project']['min_alt'], 25.0)
-        self.assertEqual(data['project']['max_sun_alt'], -10.0)
+        self.assertEqual(data['project']['max_sun_alt'], -10)
         self.assertEqual(data['project']['priority'], 3)
 
         response = self.app.patch(
@@ -2044,6 +2121,38 @@ class TestProjectOperations(unittest.TestCase):
         self.assertIsNone(data['project']['min_alt'])
         # priority (NOT NULL) is unaffected by the previous request
         self.assertEqual(data['project']['priority'], 3)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_projects_list_sort_by_priority(self, config):
+        """List API sort_by=priority orders projects by priority."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        suf = datetime.now().strftime('%H%M%S%f')
+        for priority, label in ((1, 'Lo'), (8, 'Hi'), (4, 'Mid')):
+            body = {
+                "name": f"{label}Pri{suf}", "scope_id": 1, "ra": 0.2, "decl": 2.0,
+                "priority": priority,
+            }
+            response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+            self.assertEqual(response.status_code, 201)
+
+        asc = json.loads(
+            self.app.get(
+                '/api/projects?sort_by=priority&sort_order=asc&per_page=100',
+                headers=self.headers,
+            ).data
+        )['projects']
+        ours = [p for p in asc if p['name'].endswith(suf)]
+        self.assertEqual([p['name'][:p['name'].find('Pri')] for p in ours], ['Lo', 'Mid', 'Hi'])
+
+        desc = json.loads(
+            self.app.get(
+                '/api/projects?sort_by=priority&sort_order=desc&per_page=100',
+                headers=self.headers,
+            ).data
+        )['projects']
+        ours = [p for p in desc if p['name'].endswith(suf)]
+        self.assertEqual([p['name'][:p['name'].find('Pri')] for p in ours], ['Hi', 'Mid', 'Lo'])
         os.environ.pop('HEVELIUS_DB_NAME')
 
     @use_repository

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -151,7 +151,7 @@ class TestLogChecks(unittest.TestCase):
 
     def test_latest_migration_version(self):
         # Uses the real db/ directory checked into the repo.
-        self.assertEqual(doctor.latest_migration_version("db"), 25)
+        self.assertEqual(doctor.latest_migration_version("db"), 26)
 
     def test_latest_migration_version_missing_dir(self):
         self.assertIsNone(doctor.latest_migration_version("/no/such/dir"))

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -28,7 +28,7 @@ class DbTest(unittest.TestCase):
         version = db.version_get(conn)
         conn.close()
 
-        self.assertEqual(version, 25)
+        self.assertEqual(version, 26)
 
     @use_repository
     def test_sensor(self, config):


### PR DESCRIPTION
Schema bumped to 26 (db/26-os2-scheduler-data-model.psql):
telescopes.timezone (IANA name, default UTC — real per-site values need a
manual backfill after deploy); projects gain the same observing-constraint
columns tasks already has (min_alt, moon_distance, max_moon_phase,
max_sun_alt, min_interval, all nullable); projects/tasks gain priority
(int, default 0); tasks.skip_before/skip_after/created/activated/performed
change from naive timestamp to timestamptz (values assumed already UTC).

Wires the new columns through the REST API end to end (create/update/list/
get for telescopes, projects, and tasks) and documents them in
api/openapi.yaml, matching how prior column-adding migrations in this repo
were paired with route support in the same change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011txWVHnU86Ue9nZuUPAM2t