### PR TITLE
Add night_date() function for observing night calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
   interpreter's `zoneinfo` recognizes). `telescope show`/`list` display it.
   New `hevelius telescope timezones [--filter TEXT]` lists/searches valid IANA
   names so users don't have to guess the exact spelling.
+- Added `hevelius.night.night_date()` (OS-1, observation scheduler plan): computes
+  the observing night for a UTC instant using the NINA "date - 12h" rule (convert
+  to the site's local civil time via its IANA timezone, subtract 12 hours, take
+  the date), so a night session spanning local midnight collapses onto a single
+  calendar date. Pure function, no DB dependency; shared by Night Plan (OS-4),
+  `observation_events.night_date` (OS-8), and nightly Statistics grouping (OS-9).
 - DB: schema bumped to 26 (OS-2, observation scheduler plan): `telescopes.timezone`
   (IANA name, default `UTC`; existing rows need the real value backfilled by hand);
   `projects` gains the same observing-constraint columns `tasks` has (`min_alt`,

--- a/hevelius/night.py
+++ b/hevelius/night.py
@@ -1,0 +1,34 @@
+"""
+Night identity: which observing night a UTC instant belongs to.
+
+Implements the NINA "date - 12h" rule: convert the instant to the
+telescope's local civil time, subtract 12 hours, take the date. A night
+session that spans local midnight (e.g. starts at 22:00, ends at 03:00
+local) therefore collapses onto a single calendar date - the evening's
+date.
+
+Shared by Night Plan (OS-4), `observation_events.night_date` (OS-8), and
+nightly Statistics grouping (OS-9) so all three consumers bucket
+observations into nights the same way. Pure function, no DB dependency:
+callers pass the telescope's IANA timezone name (`telescopes.timezone`,
+see OS-2) rather than a scope/telescope object.
+"""
+
+import datetime
+from zoneinfo import ZoneInfo
+
+
+def night_date(t: datetime.datetime, tz_name: str) -> datetime.date:
+    """
+    Returns the observing night (a date) that the UTC instant `t` belongs
+    to at the site identified by the IANA timezone `tz_name`
+    (e.g. "Europe/Warsaw").
+
+    `t` may be a naive datetime (assumed to already be UTC) or a
+    timezone-aware datetime in any zone (converted to UTC first).
+    """
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=datetime.timezone.utc)
+
+    local = t.astimezone(ZoneInfo(tz_name))
+    return (local - datetime.timedelta(hours=12)).date()

--- a/tests/test_night.py
+++ b/tests/test_night.py
@@ -1,0 +1,58 @@
+"""
+Tests hevelius.night.night_date() - the NINA "date - 12h" night identity rule.
+"""
+
+import datetime
+
+import pytest
+
+from hevelius.night import night_date
+
+WARSAW = "Europe/Warsaw"
+UTC = datetime.timezone.utc
+
+
+# Worked examples from the issue: site in Europe/Warsaw (UTC+2, CEST, in
+# August), evening / late-night / next-afternoon cases.
+@pytest.mark.parametrize("utc_time, expected_date", [
+    # Local 2026-08-03 22:00 CEST -> UTC 2026-08-03 20:00
+    (datetime.datetime(2026, 8, 3, 20, 0, 0, tzinfo=UTC), datetime.date(2026, 8, 3)),
+    # Local 2026-08-04 03:00 CEST -> UTC 2026-08-04 01:00
+    (datetime.datetime(2026, 8, 4, 1, 0, 0, tzinfo=UTC), datetime.date(2026, 8, 3)),
+    # Local 2026-08-04 13:00 CEST -> UTC 2026-08-04 11:00
+    (datetime.datetime(2026, 8, 4, 11, 0, 0, tzinfo=UTC), datetime.date(2026, 8, 4)),
+])
+def test_night_date_worked_examples(utc_time, expected_date):
+    assert night_date(utc_time, WARSAW) == expected_date
+
+
+def test_night_date_boundary_at_local_noon():
+    """Local 12:00:00 minus 12h lands exactly on local midnight: same day."""
+    utc_time = datetime.datetime(2026, 8, 4, 10, 0, 0, tzinfo=UTC)  # local 12:00:00 CEST
+    assert night_date(utc_time, WARSAW) == datetime.date(2026, 8, 4)
+
+
+def test_night_date_boundary_just_before_local_noon():
+    """One second earlier, it rolls back onto the previous night."""
+    utc_time = datetime.datetime(2026, 8, 4, 9, 59, 59, tzinfo=UTC)  # local 11:59:59 CEST
+    assert night_date(utc_time, WARSAW) == datetime.date(2026, 8, 3)
+
+
+def test_night_date_naive_datetime_assumed_utc():
+    """A naive datetime is treated as if it were already UTC."""
+    aware = datetime.datetime(2026, 8, 3, 20, 0, 0, tzinfo=UTC)
+    naive = datetime.datetime(2026, 8, 3, 20, 0, 0)
+    assert night_date(naive, WARSAW) == night_date(aware, WARSAW)
+
+
+def test_night_date_aware_datetime_in_other_timezone_is_converted():
+    """The same instant, expressed in a different zone, gives the same result."""
+    utc_time = datetime.datetime(2026, 8, 4, 1, 0, 0, tzinfo=UTC)
+    eastern_time = utc_time.astimezone(datetime.timezone(datetime.timedelta(hours=-4)))
+    assert night_date(eastern_time, WARSAW) == night_date(utc_time, WARSAW)
+
+
+def test_night_date_utc_site():
+    """A telescope with tz_name='UTC' just applies the -12h rule directly."""
+    utc_time = datetime.datetime(2026, 8, 3, 20, 0, 0, tzinfo=UTC)
+    assert night_date(utc_time, "UTC") == datetime.date(2026, 8, 3)


### PR DESCRIPTION
## Summary
Implements the `night_date()` function in a new `hevelius.night` module to compute the observing night for a UTC instant using the NINA "date - 12h" rule. This pure function will be shared across multiple components of the observation scheduler.

## Changes
- **New module `hevelius/night.py`**: Implements `night_date(t, tz_name)` function that:
  - Converts a UTC instant to the telescope site's local civil time using its IANA timezone name
  - Subtracts 12 hours from the local time
  - Returns the resulting date
  - Handles both naive datetimes (assumed UTC) and timezone-aware datetimes in any zone
  
- **Comprehensive test suite `tests/test_night.py`**: 58 lines of tests covering:
  - Worked examples from the specification (evening, late-night, and next-afternoon cases)
  - Boundary conditions at local noon (±1 second)
  - Naive datetime handling (assumed UTC)
  - Timezone-aware datetime conversion
  - UTC site handling

- **Updated CHANGELOG.md**: Documents the new feature and its role in the observation scheduler plan (OS-1, OS-4, OS-8, OS-9)

## Implementation Details
- Uses Python's `zoneinfo.ZoneInfo` for timezone handling
- Pure function with no database dependencies; callers pass the telescope's IANA timezone name
- The "date - 12h" rule ensures that night sessions spanning local midnight (e.g., 22:00–03:00) collapse onto a single calendar date (the evening's date)
- Will be shared by Night Plan (OS-4), `observation_events.night_date` (OS-8), and nightly Statistics grouping (OS-9) for consistent night bucketing

https://claude.ai/code/session_01FqEauXYQ9DzBbWtx2rm6wu