### PR TITLE
Add telescope timezone support with IANA validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 
 ## 0.7.0 (unreleased)
 
+- CLI: `hevelius telescope add`/`edit` accept `--timezone` (IANA name, e.g.
+  `Europe/Warsaw`; rejected up front, before any DB write, if not a name the
+  interpreter's `zoneinfo` recognizes). `telescope show`/`list` display it.
+  New `hevelius telescope timezones [--filter TEXT]` lists/searches valid IANA
+  names so users don't have to guess the exact spelling.
 - DB: schema bumped to 26 (OS-2, observation scheduler plan): `telescopes.timezone`
   (IANA name, default `UTC`; existing rows need the real value backfilled by hand);
   `projects` gains the same observing-constraint columns `tasks` has (`min_alt`,

--- a/bin/hevelius
+++ b/bin/hevelius
@@ -46,6 +46,7 @@ from hevelius.equipment import (
     set_telescope_sensor,
     add_telescope_filter,
     remove_telescope_filter,
+    list_timezones,
 )
 from hevelius.asteroid import (
     asteroids_download,
@@ -356,6 +357,11 @@ def run():
     t_add.add_argument('--alt', type=float, help="Altitude")
     t_add.add_argument('--sensor-id', type=int, default=None, help="Sensor ID (0 or omit = none)")
     t_add.add_argument('--default-rotation', type=float, default=None, help="Default rotation (deg, East of North) for new projects on this telescope")
+    t_add.add_argument(
+        '--timezone', default=None,
+        help="IANA timezone name for the site, e.g. Europe/Warsaw (default 'UTC' if omitted); "
+             "used to compute the observing night boundary. Find valid names with "
+             "'hevelius telescope timezones --filter <text>'")
     t_add.add_argument('--active', action='store_true', default=True, help="Telescope is active (default)")
     t_add.add_argument('--inactive', action='store_true', help="Create telescope as inactive")
     t_edit = telescope_sub.add_parser('edit', help="Edit an existing telescope")
@@ -372,6 +378,11 @@ def run():
     t_edit.add_argument('--sensor-id', type=int, default=None, help="Sensor ID (0 to remove)")
     t_edit.add_argument('--default-rotation', type=float, default=None, help="Default rotation (deg, East of North) for new projects on this telescope")
     t_edit.add_argument('--clear-default-rotation', action='store_true', help="Clear default_rotation (set to null)")
+    t_edit.add_argument(
+        '--timezone', default=None,
+        help="IANA timezone name for the site, e.g. Europe/Warsaw; "
+             "used to compute the observing night boundary. Find valid names with "
+             "'hevelius telescope timezones --filter <text>'")
     t_edit.add_argument('--active', action='store_true', help="Set active")
     t_edit.add_argument('--inactive', action='store_true', help="Set inactive")
     t_show = telescope_sub.add_parser('show', help="Show telescope details (sensor + filters)")
@@ -385,6 +396,12 @@ def run():
     t_remfilter = telescope_sub.add_parser('remove-filter', help="Remove a filter from the telescope")
     t_remfilter.add_argument('scope_id', type=int, help="Telescope scope_id")
     t_remfilter.add_argument('filter_id', type=int, help="Filter ID to remove")
+    t_timezones = telescope_sub.add_parser(
+        'timezones',
+        help="List valid IANA timezone names accepted by --timezone (optionally filtered)")
+    t_timezones.add_argument(
+        '--filter', dest='tz_filter', default=None,
+        help="Case-insensitive substring filter, e.g. --filter warsaw")
 
     user_parser = subparsers.add_parser('user', help="List, add, enable, or disable a user")
     user_sub = user_parser.add_subparsers(dest='user_command', help="User subcommand")
@@ -779,7 +796,8 @@ def run():
                 alt=getattr(args, 'alt', None),
                 sensor_id=getattr(args, 'sensor_id', None),
                 active=active,
-                default_rotation=getattr(args, 'default_rotation', None)
+                default_rotation=getattr(args, 'default_rotation', None),
+                timezone=getattr(args, 'timezone', None)
             ) is not None else 1
         if args.telescope_command == "edit":
             active = None
@@ -806,7 +824,8 @@ def run():
                 sensor_id=getattr(args, 'sensor_id', None),
                 active=active,
                 default_rotation=getattr(args, 'default_rotation', None),
-                clear_default_rotation=getattr(args, 'clear_default_rotation', False)
+                clear_default_rotation=getattr(args, 'clear_default_rotation', False),
+                timezone=getattr(args, 'timezone', None)
             ) else 1
         if args.telescope_command == "show":
             return show_telescope(args.scope_id)
@@ -816,6 +835,9 @@ def run():
             return 0 if add_telescope_filter(args.scope_id, args.filter_id) else 1
         if args.telescope_command == "remove-filter":
             return 0 if remove_telescope_filter(args.scope_id, args.filter_id) else 1
+        if args.telescope_command == "timezones":
+            list_timezones(getattr(args, 'tz_filter', None))
+            return 0
         return telescope_parser.print_help() or 1
     if args.command == "user":
         if args.user_command == "list":

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -43,6 +43,37 @@ hevelius telescope list
 hevelius user list
 ```
 
+## Telescope timezone
+
+`telescope add` and `telescope edit` accept `--timezone`, an **IANA time
+zone name** (e.g. `Europe/Warsaw`, `America/Santiago`, `Africa/Windhoek`) —
+the same names used by the `tz`/Olson database and validated against the
+Python interpreter's own zone data (`zoneinfo`). It's the per-telescope
+site zone used to compute the observing night boundary (the "local time -
+12h" rule; see `hevelius.night`). It defaults to `UTC` if never set.
+
+Rather than guessing the exact spelling, search the CLI's own list:
+
+```shell
+hevelius telescope timezones --filter warsaw
+# Europe/Warsaw
+#
+# 1 timezone(s) matching 'warsaw'.
+
+hevelius telescope timezones --filter africa
+hevelius telescope timezones   # full list (several hundred entries)
+```
+
+The full canonical list is also documented at
+https://en.wikipedia.org/wiki/List_of_tz_database_time_zones. An invalid
+name is rejected with an error at `add`/`edit` time, before the database
+is touched:
+
+```shell
+hevelius telescope edit 3 --timezone Europe/Warsaw
+hevelius telescope show 3
+```
+
 ## Doctor
 
 `hevelius doctor` runs a series of sanity checks on the local installation

--- a/hevelius/equipment.py
+++ b/hevelius/equipment.py
@@ -3,6 +3,7 @@ CLI commands for filters, sensors (cameras), and projects.
 """
 
 import difflib
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
 
 from hevelius import db
 
@@ -526,6 +527,32 @@ def remove_task_from_project(project_id, task_id):
 SCOPE_SORT_FIELDS = {"scope_id", "name", "focal", "active"}
 
 
+def _is_valid_timezone(tz_name):
+    """Returns True if tz_name is a valid IANA timezone name (per the system's tzdata)."""
+    try:
+        ZoneInfo(tz_name)
+        return True
+    except (ZoneInfoNotFoundError, KeyError, ValueError):
+        return False
+
+
+def list_timezones(name_filter=None):
+    """Print IANA timezone names accepted by `telescope add`/`telescope edit --timezone`,
+    optionally narrowed to those containing name_filter (case-insensitive substring,
+    e.g. 'warsaw' or 'europe')."""
+    names = sorted(available_timezones())
+    if name_filter:
+        needle = name_filter.lower()
+        names = [n for n in names if needle in n.lower()]
+    if not names:
+        print(f"No timezones matching {name_filter!r}.")
+        return
+    for n in names:
+        print(n)
+    suffix = f" matching {name_filter!r}" if name_filter else ""
+    print(f"\n{len(names)} timezone(s){suffix}.")
+
+
 def list_telescopes(sort_by="scope_id", sort_order="asc"):
     """List all telescopes with optional sorting (scope_id, name, focal, active)."""
     if sort_by not in SCOPE_SORT_FIELDS:
@@ -536,7 +563,7 @@ def list_telescopes(sort_by="scope_id", sort_order="asc"):
     cnx = db.connect()
     rows = db.run_query(cnx, f"""
         SELECT t.scope_id, t.name, t.descr, t.min_dec, t.max_dec, t.focal, t.aperture,
-               t.lon, t.lat, t.alt, t.sensor_id, t.active,
+               t.lon, t.lat, t.alt, t.sensor_id, t.active, t.timezone,
                s.name AS sensor_name
         FROM telescopes t
         LEFT JOIN sensors s ON t.sensor_id = s.sensor_id
@@ -546,18 +573,27 @@ def list_telescopes(sort_by="scope_id", sort_order="asc"):
     if not rows:
         print("No telescopes found.")
         return
-    print(f"{'ID':<6} {'Name':<24} {'Focal':<8} {'Sensor':<22} Active")
-    print("-" * 75)
+    print(f"{'ID':<6} {'Name':<24} {'Focal':<8} {'Sensor':<22} {'Timezone':<20} Active")
+    print("-" * 95)
     for r in rows:
         name = (r[1] or "")[:22]
         focal = r[5] if r[5] is not None else ""
-        sensor = (r[12] or "")[:20] if len(r) > 12 else ""
-        print(f"{r[0]:<6} {name:<24} {focal!s:<8} {sensor:<22} {r[11]}")
+        timezone = (r[12] or "")[:18]
+        sensor = (r[13] or "")[:20] if len(r) > 13 else ""
+        print(f"{r[0]:<6} {name:<24} {focal!s:<8} {sensor:<22} {timezone:<20} {r[11]}")
 
 
 def add_telescope(name, scope_id=None, descr=None, min_dec=None, max_dec=None, focal=None, aperture=None,
-                  lon=None, lat=None, alt=None, sensor_id=None, active=True, default_rotation=None):
-    """Add a new telescope. scope_id is optional (auto-assigned if omitted). Returns scope_id on success, None on failure."""
+                  lon=None, lat=None, alt=None, sensor_id=None, active=True, default_rotation=None,
+                  timezone=None):
+    """Add a new telescope. scope_id is optional (auto-assigned if omitted). timezone is an
+    IANA name (e.g. 'Europe/Warsaw'), defaults to 'UTC' in the DB if omitted.
+    Returns scope_id on success, None on failure."""
+    if timezone is not None and not _is_valid_timezone(timezone):
+        print(f"Error: {timezone!r} is not a valid IANA timezone name. "
+              "Run 'hevelius telescope timezones --filter <text>' to search for one, or see "
+              "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones")
+        return None
     if sensor_id == 0:
         sensor_id = None
     cnx = db.connect()
@@ -575,7 +611,7 @@ def add_telescope(name, scope_id=None, descr=None, min_dec=None, max_dec=None, f
     for key, val in [
         ("descr", descr), ("min_dec", min_dec), ("max_dec", max_dec), ("focal", focal),
         ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active),
-        ("default_rotation", default_rotation)
+        ("default_rotation", default_rotation), ("timezone", timezone)
     ]:
         if val is not None:
             cols.append(key)
@@ -597,9 +633,15 @@ def add_telescope(name, scope_id=None, descr=None, min_dec=None, max_dec=None, f
 
 def edit_telescope(scope_id, name=None, descr=None, min_dec=None, max_dec=None, focal=None, aperture=None,
                    lon=None, lat=None, alt=None, sensor_id=None, active=None,
-                   default_rotation=None, clear_default_rotation=False):
-    """Edit an existing telescope. sensor_id=0 removes the sensor.
-    clear_default_rotation=True sets default_rotation to NULL. Returns True on success."""
+                   default_rotation=None, clear_default_rotation=False, timezone=None):
+    """Edit an existing telescope. sensor_id=0 removes the sensor. timezone is an IANA name
+    (e.g. 'Europe/Warsaw'). clear_default_rotation=True sets default_rotation to NULL.
+    Returns True on success."""
+    if timezone is not None and not _is_valid_timezone(timezone):
+        print(f"Error: {timezone!r} is not a valid IANA timezone name. "
+              "Run 'hevelius telescope timezones --filter <text>' to search for one, or see "
+              "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones")
+        return False
     cnx = db.connect()
     row = db.run_query(cnx, "SELECT scope_id FROM telescopes WHERE scope_id = %s", (scope_id,))
     if not row:
@@ -610,7 +652,8 @@ def edit_telescope(scope_id, name=None, descr=None, min_dec=None, max_dec=None, 
     params = []
     for key, val in [
         ("name", name), ("descr", descr), ("min_dec", min_dec), ("max_dec", max_dec),
-        ("focal", focal), ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active)
+        ("focal", focal), ("aperture", aperture), ("lon", lon), ("lat", lat), ("alt", alt), ("active", active),
+        ("timezone", timezone)
     ]:
         if val is not None:
             updates.append(f"{key} = %s")
@@ -640,7 +683,7 @@ def show_telescope(scope_id):
     cnx = db.connect()
     row = db.run_query(cnx, """
         SELECT t.scope_id, t.name, t.descr, t.min_dec, t.max_dec, t.focal, t.aperture,
-               t.lon, t.lat, t.alt, t.sensor_id, t.active, t.default_rotation
+               t.lon, t.lat, t.alt, t.sensor_id, t.active, t.default_rotation, t.timezone
         FROM telescopes t WHERE t.scope_id = %s
     """, (scope_id,))
     if not row:
@@ -656,6 +699,7 @@ def show_telescope(scope_id):
     print(f"Focal:     {r[5]}")
     print(f"Aperture:  {r[6]}")
     print(f"Lon/Lat/Alt: {r[7]} / {r[8]} / {r[9]}")
+    print(f"Timezone:  {r[13]}")
     print(f"Active:    {r[11]}")
     print(f"Default rotation: {r[12]}")
     if r[10] is not None:

--- a/tests/test_cmd_telescope.py
+++ b/tests/test_cmd_telescope.py
@@ -1,0 +1,124 @@
+"""
+Tests telescope timezone support: hevelius.equipment.list_timezones,
+add_telescope/edit_telescope --timezone validation and persistence.
+"""
+
+import contextlib
+import io
+import os
+import unittest
+
+from hevelius import db
+from hevelius.equipment import (
+    _is_valid_timezone,
+    list_timezones,
+    add_telescope,
+    edit_telescope,
+)
+from tests.dbtest import use_repository
+
+
+class TestTimezoneValidation(unittest.TestCase):
+    """Pure logic, no DB: timezone name validation and the `timezones` lookup command."""
+
+    def test_is_valid_timezone(self):
+        """Valid/invalid IANA names are accepted/rejected."""
+        self.assertTrue(_is_valid_timezone("Europe/Warsaw"))
+        self.assertTrue(_is_valid_timezone("UTC"))
+        self.assertFalse(_is_valid_timezone("Not/AZone"))
+        self.assertFalse(_is_valid_timezone(""))
+
+    def test_list_timezones_filter(self):
+        """`telescope timezones --filter` narrows to matching names, case-insensitively."""
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            list_timezones("warsaw")
+        output = buf.getvalue()
+        self.assertIn("Europe/Warsaw", output)
+        self.assertIn("1 timezone(s) matching 'warsaw'", output)
+
+    def test_list_timezones_no_match(self):
+        """A filter matching nothing prints a clear message instead of an empty list."""
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            list_timezones("nonexistent-zone-zzz")
+        output = buf.getvalue()
+        self.assertIn("No timezones matching", output)
+
+    def test_add_telescope_rejects_invalid_timezone_without_db(self):
+        """Validation happens before any DB connection is attempted."""
+        result = add_telescope("Should Not Be Created", timezone="Not/AZone")
+        self.assertIsNone(result)
+
+    def test_edit_telescope_rejects_invalid_timezone_without_db(self):
+        """Same early-validation guarantee for edit as for add."""
+        result = edit_telescope(1, timezone="Not/AZone")
+        self.assertFalse(result)
+
+
+class TestTelescopeTimezoneDb(unittest.TestCase):
+    """DB-backed: add_telescope/edit_telescope actually persist --timezone."""
+
+    @use_repository
+    def test_add_telescope_with_timezone(self, config):
+        """A valid --timezone is stored as given."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        try:
+            scope_id = add_telescope("CLI TZ Test Scope", timezone="Europe/Warsaw")
+            self.assertIsNotNone(scope_id)
+            conn = db.connect()
+            rows = db.run_query(conn, "SELECT timezone FROM telescopes WHERE scope_id = %s", (scope_id,))
+            conn.close()
+            self.assertEqual(rows[0][0], "Europe/Warsaw")
+        finally:
+            os.environ.pop('HEVELIUS_DB_NAME', None)
+
+    @use_repository
+    def test_add_telescope_without_timezone_defaults_to_utc(self, config):
+        """Omitting --timezone falls back to the DB column default ('UTC')."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        try:
+            scope_id = add_telescope("CLI TZ Default Scope")
+            self.assertIsNotNone(scope_id)
+            conn = db.connect()
+            rows = db.run_query(conn, "SELECT timezone FROM telescopes WHERE scope_id = %s", (scope_id,))
+            conn.close()
+            self.assertEqual(rows[0][0], "UTC")
+        finally:
+            os.environ.pop('HEVELIUS_DB_NAME', None)
+
+    @use_repository
+    def test_edit_telescope_updates_timezone(self, config):
+        """edit_telescope(timezone=...) updates an existing telescope's zone."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        try:
+            scope_id = add_telescope("CLI TZ Edit Scope")
+            self.assertIsNotNone(scope_id)
+            ok = edit_telescope(scope_id, timezone="America/Santiago")
+            self.assertTrue(ok)
+            conn = db.connect()
+            rows = db.run_query(conn, "SELECT timezone FROM telescopes WHERE scope_id = %s", (scope_id,))
+            conn.close()
+            self.assertEqual(rows[0][0], "America/Santiago")
+        finally:
+            os.environ.pop('HEVELIUS_DB_NAME', None)
+
+    @use_repository
+    def test_edit_telescope_invalid_timezone_leaves_db_unchanged(self, config):
+        """A rejected --timezone on edit doesn't touch the stored value."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        try:
+            scope_id = add_telescope("CLI TZ Unchanged Scope", timezone="Europe/Warsaw")
+            self.assertIsNotNone(scope_id)
+            ok = edit_telescope(scope_id, timezone="Not/AZone")
+            self.assertFalse(ok)
+            conn = db.connect()
+            rows = db.run_query(conn, "SELECT timezone FROM telescopes WHERE scope_id = %s", (scope_id,))
+            conn.close()
+            self.assertEqual(rows[0][0], "Europe/Warsaw")
+        finally:
+            os.environ.pop('HEVELIUS_DB_NAME', None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds comprehensive timezone support to the telescope management system, allowing users to specify and manage IANA timezone names for each telescope site. Includes validation, CLI commands for timezone discovery, and database persistence.

## Key Changes

- **Timezone validation**: New `_is_valid_timezone()` function validates IANA timezone names against the system's `zoneinfo` database before any database operations
- **Timezone discovery CLI**: New `hevelius telescope timezones [--filter TEXT]` command lists valid IANA timezone names with optional case-insensitive filtering (e.g., `--filter warsaw`)
- **Add/edit telescope support**: Both `add_telescope()` and `edit_telescope()` now accept an optional `--timezone` parameter; invalid timezones are rejected with helpful error messages before DB writes
- **Database persistence**: Timezone values are stored in and retrieved from the `telescopes.timezone` column (defaults to `UTC` if omitted)
- **Display updates**: `list_telescopes()` and `show_telescope()` now display the timezone for each telescope
- **CLI argument handling**: Added `--timezone` arguments to `telescope add` and `telescope edit` subcommands with help text directing users to the timezone discovery command
- **Documentation**: Updated `doc/commands.md` with timezone usage examples and references to the IANA timezone list

## Implementation Details

- Uses Python's built-in `zoneinfo` module for timezone validation, ensuring compatibility with the system's tzdata
- Early validation (before DB connection) prevents invalid data from being persisted
- Timezone filtering is case-insensitive substring matching for user convenience
- Error messages include helpful guidance pointing users to the `timezones` command and Wikipedia reference
- Comprehensive test coverage including validation logic, CLI filtering, and database persistence across add/edit operations

https://claude.ai/code/session_01FqEauXYQ9DzBbWtx2rm6wu