### PR TITLE
Implement OS-3: shared observability engine (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
 
 ## 0.7.0 (unreleased)
 
+- Added `hevelius.observability` (OS-3, observation scheduler plan): a
+  generic, staged target-visibility engine operating on plain
+  `(ra_deg, dec_deg, constraints)` rather than task/project rows, so it's
+  reusable by both. Mirrors `hevelius asteroid visible`'s cheap-filters-first
+  structure - transit-altitude check, night hour-angle overlap, a
+  representative-moment sun/moon check, then a precise `astropy`
+  GCRS/ICRS → AltAz confirm for survivors - and will be the engine behind
+  the Night Plan rewrite (OS-4, #46). Also extracted the underlying
+  astronomy primitives (`get_night_times`, `moon_rise_set`,
+  `transit_altitude_deg`, `ha_window_visible`, plus new `sun_altitude_deg`,
+  `moon_separation_deg`, `moon_illumination_pct`) out of
+  `hevelius/asteroid.py` into `hevelius/night.py` so they're shared rather
+  than asteroid-specific; no behavior change for the existing asteroid
+  visibility feature.
 - CLI: `hevelius telescope add`/`edit` accept `--timezone` (IANA name, e.g.
   `Europe/Warsaw`; rejected up front, before any DB write, if not a name the
   interpreter's `zoneinfo` recognizes). `telescope show`/`list` display it.

--- a/hevelius/asteroid.py
+++ b/hevelius/asteroid.py
@@ -18,15 +18,13 @@ from astropy.coordinates import (
     EarthLocation,
     GCRS,
     get_body,
-    get_sun,
     solar_system_ephemeris,
 )
 from astropy.time import Time
 from astropy import units as u
-from astropy.utils import iers
 import numpy as np
 
-from hevelius import db
+from hevelius import db, night
 from hevelius.config import load_config
 
 # MPCORB.DAT fixed-width columns (0-based); format from MPC Export Format.
@@ -59,25 +57,6 @@ MPCORB_MAX_AGE_DAYS = 7
 # Base-62 alphabet used in MPC packed permanent designations (>= 620000).
 _BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 _BASE62_INDEX = {c: i for i, c in enumerate(_BASE62)}
-
-
-def _configure_iers_for_planning() -> None:
-    """
-    Allow IERS age extrapolation for offline/future observation planning.
-
-    Recent/future dates need up-to-date Earth orientation (IERS) data, normally
-    auto-downloaded. Without network access (or if the download fails), astropy
-    raises rather than falling back to extrapolated values. The extrapolation
-    error is sub-arcsecond and irrelevant for altitude/visibility purposes, so
-    disable the hard age limit when running visibility computations.
-
-    Applied lazily from visibility entry points only (idempotent via the
-    auto_max_age sentinel), so importing this module for MPCORB parsing does
-    not change global IERS behaviour for unrelated astropy callers.
-    """
-    if iers.conf.auto_max_age is None:
-        return
-    iers.conf.auto_max_age = None
 
 
 def _progress(msg: str) -> None:
@@ -594,117 +573,6 @@ def _apparent_magnitude(H: float, G: float, r_au: float, delta_au: float, phase_
     return H + 5 * np.log10(r_au * delta_au) - 2.5 * np.log10(phi)
 
 
-def _altitude_series(body_fn, location: EarthLocation, t0: Time, t1: Time, n: int = 481):
-    """
-    Sample altitude (degrees) of a solar-system body from t0 to t1 inclusive.
-
-    body_fn(times) -> SkyCoord (e.g. get_sun, or lambda t: get_body('moon', t)).
-    """
-    duration_h = (t1 - t0).to(u.hour).value
-    times = t0 + np.linspace(0.0, duration_h, n) * u.hour
-    frame = AltAz(obstime=times, location=location)
-    alt = body_fn(times).transform_to(frame).alt.to(u.deg).value
-    return times, np.asarray(alt, dtype=float)
-
-
-def _find_zero_crossings(times: Time, alts: np.ndarray, level: float = 0.0):
-    """
-    Linearly interpolate times where altitude crosses `level`.
-
-    Returns list of (Time, direction) with direction 'up' or 'down'.
-    """
-    crossings = []
-    for i in range(len(alts) - 1):
-        a0, a1 = alts[i] - level, alts[i + 1] - level
-        if a0 == 0:
-            # Exact hit: infer direction from the next sample when possible.
-            if a1 > 0:
-                crossings.append((times[i], "up"))
-            elif a1 < 0:
-                crossings.append((times[i], "down"))
-            continue
-        if a0 * a1 > 0:
-            continue
-        if a0 * a1 == 0 and a1 == 0:
-            continue
-        frac = abs(a0) / (abs(a0) + abs(a1) + 1e-20)
-        t_cross = times[i] + frac * (times[i + 1] - times[i])
-        crossings.append((t_cross, "up" if a1 > a0 else "down"))
-    return crossings
-
-
-def _get_night_times(location: EarthLocation, obs_time: Time) -> Tuple[Time, Time]:
-    """
-    Return (sunset, sunrise) in UTC for the night beginning on obs_time's date.
-
-    The night runs from geometric sunset (sun altitude crossing 0° downward)
-    on the evening of that calendar date through geometric sunrise the next
-    morning. This matches observer "night" even when astronomical twilight
-    never occurs (e.g. mid-latitude summer).
-
-    If the Sun never sets (polar day), falls back to a 12-hour window centred
-    on local solar midnight as a last resort. If the Sun never rises (polar
-    night), returns noon→next-noon.
-    """
-    # Search from noon UTC on the evening date through noon the next day.
-    date_str = obs_time.iso[:10]
-    noon = Time(f"{date_str} 12:00:00")
-    times, alts = _altitude_series(get_sun, location, noon, noon + 24 * u.hour, n=577)
-    crossings = _find_zero_crossings(times, alts, level=0.0)
-
-    sunset = next((t for t, d in crossings if d == "down"), None)
-    sunrise = None
-    if sunset is not None:
-        sunrise = next((t for t, d in crossings if d == "up" and t > sunset), None)
-
-    if sunset is not None and sunrise is not None and sunrise > sunset:
-        return sunset, sunrise
-
-    # Polar night: sun always below horizon across the window.
-    if np.all(alts < 0):
-        return noon, noon + 24 * u.hour
-
-    # Polar day / no clear night: last-resort evening-centred window (NOT daytime).
-    midnight = noon + 12 * u.hour
-    return midnight - 6 * u.hour, midnight + 6 * u.hour
-
-
-def _moon_rise_set(location: EarthLocation, night_start: Time, night_end: Time):
-    """
-    Find moonrise/moonset near the given night.
-
-    Searches a padded window around the night so events just outside sunset/
-    sunrise are still reported. Returns (moonrise, moonset) as Time or None.
-    """
-    pad = 6 * u.hour
-    times, alts = _altitude_series(
-        lambda t: get_body("moon", t),
-        location,
-        night_start - pad,
-        night_end + pad,
-        n=721,
-    )
-    crossings = _find_zero_crossings(times, alts, level=0.0)
-    rises = [t for t, d in crossings if d == "up"]
-    sets = [t for t, d in crossings if d == "down"]
-
-    moonrise = next((r for r in rises if r <= night_end + pad), None)
-    moonset = None
-    if moonrise is not None:
-        moonset = next((s for s in sets if s > moonrise), None)
-    elif sets:
-        # Moon already up at window start: report the upcoming set.
-        moonset = sets[0]
-
-    return moonrise, moonset
-
-
-def _moon_altitudes(location: EarthLocation, times: Time) -> np.ndarray:
-    """Moon altitude in degrees at each sample time."""
-    frame = AltAz(obstime=times, location=location)
-    return get_body("moon", times).transform_to(frame).alt.to(u.deg).value
-
-
 def _xyz_to_radec(x: float, y: float, z: float) -> Tuple[float, float]:
     """Convert equatorial Cartesian to RA/Dec in degrees."""
     r = np.sqrt(x * x + y * y + z * z)
@@ -713,47 +581,6 @@ def _xyz_to_radec(x: float, y: float, z: float) -> Tuple[float, float]:
     dec = np.degrees(np.arcsin(np.clip(z / r, -1.0, 1.0)))
     ra = np.degrees(np.arctan2(y, x)) % 360.0
     return ra, dec
-
-
-def _transit_altitude(dec_deg: float, lat_deg: float) -> float:
-    """Maximum altitude an object ever reaches (at upper transit)."""
-    return 90.0 - abs(lat_deg - dec_deg)
-
-
-def _night_visible(ra_deg: float, dec_deg: float, lat_deg: float,
-                   lst_mid_deg: float, night_half_hours: float,
-                   alt_min_deg: float) -> bool:
-    """
-    Quick test: is the object above alt_min at any moment during the night?
-
-    Uses hour-angle arithmetic to determine whether the window in which the
-    object is above alt_min overlaps with the night window (centred on midnight).
-    """
-    lat = np.radians(lat_deg)
-    dec = np.radians(dec_deg)
-    alt_min = np.radians(alt_min_deg)
-
-    sin_alt_transit = np.sin(dec) * np.sin(lat) + np.cos(dec) * np.cos(lat)
-    if sin_alt_transit < np.sin(alt_min):
-        return False
-
-    cos_ha_thresh = (np.sin(alt_min) - np.sin(dec) * np.sin(lat)) / (
-        np.cos(dec) * np.cos(lat) + 1e-12
-    )
-
-    lst_half_deg = night_half_hours * 15.0
-
-    if cos_ha_thresh <= -1.0:
-        return True  # circumpolar above alt_min
-
-    if cos_ha_thresh >= 1.0:
-        return False  # never reaches alt_min
-
-    ha_thresh_deg = np.degrees(np.arccos(cos_ha_thresh))
-
-    # Angular separation between object RA and LST at midnight
-    center_sep = abs(((ra_deg - lst_mid_deg) + 180.0) % 360.0 - 180.0)
-    return center_sep < (ha_thresh_deg + lst_half_deg)
 
 
 def compute_visibility(
@@ -791,12 +618,12 @@ def compute_visibility(
     Returns:
         List of visible asteroids with designation, magnitude, max_altitude, etc.
     """
-    _configure_iers_for_planning()
+    night._configure_iers_for_planning()
 
     obs_time = Time(obs_date + " 00:00:00")
 
     _progress("Computing night window...")
-    night_start, night_end = _get_night_times(location, obs_time)
+    night_start, night_end = night.get_night_times(location, obs_time)
     night_duration_h = (night_end - night_start).to(u.hour).value
     night_half_h = night_duration_h / 2.0
     t_midnight = night_start + night_half_h * u.hour
@@ -923,12 +750,12 @@ def compute_visibility(
 
             # Quick check a: transit altitude
             ra_deg, dec_deg = _xyz_to_radec(ast_geo[0], ast_geo[1], ast_geo[2])
-            if _transit_altitude(dec_deg, lat_deg) < alt_min:
+            if night.transit_altitude_deg(dec_deg, lat_deg) < alt_min:
                 skipped_altitude += 1
                 continue
 
             # Quick check b: night hour-angle overlap
-            if not _night_visible(ra_deg, dec_deg, lat_deg, lst_midnight_deg, night_half_h, alt_min):
+            if not night.ha_window_visible(ra_deg, dec_deg, lat_deg, lst_midnight_deg, night_half_h, alt_min):
                 skipped_night += 1
                 continue
 
@@ -1045,9 +872,9 @@ def compute_asteroid_visibility_curve(
     (number, designation, _name, epoch_s, M_epoch, peri, node, inc, e, n, a, H, G) = asteroid_row
     G = G if G is not None else 0.15
 
-    _configure_iers_for_planning()
+    night._configure_iers_for_planning()
     obs_time = Time(obs_date + " 00:00:00")
-    night_start, night_end = _get_night_times(location, obs_time)
+    night_start, night_end = night.get_night_times(location, obs_time)
     duration_h = (night_end - night_start).to(u.hour).value
     n_samples = max(2, int(duration_h * 60 / step_minutes) + 1)
     times = night_start + np.linspace(0, duration_h, n_samples) * u.hour
@@ -1056,8 +883,8 @@ def compute_asteroid_visibility_curve(
 
     with solar_system_ephemeris.set("builtin"):
         earth_positions = get_body("earth", times)
-        moon_alt = _moon_altitudes(location, times)
-        moonrise, moonset = _moon_rise_set(location, night_start, night_end)
+        moon_alt = night._moon_altitudes(location, times)
+        moonrise, moonset = night.moon_rise_set(location, night_start, night_end)
     ex = earth_positions.cartesian.x.to(u.AU).value
     ey = earth_positions.cartesian.y.to(u.AU).value
     ez = earth_positions.cartesian.z.to(u.AU).value

--- a/hevelius/night.py
+++ b/hevelius/night.py
@@ -1,21 +1,34 @@
 """
-Night identity: which observing night a UTC instant belongs to.
+Night identity and shared astronomy primitives.
 
-Implements the NINA "date - 12h" rule: convert the instant to the
-telescope's local civil time, subtract 12 hours, take the date. A night
-session that spans local midnight (e.g. starts at 22:00, ends at 03:00
-local) therefore collapses onto a single calendar date - the evening's
-date.
+Night identity: which observing night a UTC instant belongs to. Implements
+the NINA "date - 12h" rule: convert the instant to the telescope's local
+civil time, subtract 12 hours, take the date. A night session that spans
+local midnight (e.g. starts at 22:00, ends at 03:00 local) therefore
+collapses onto a single calendar date - the evening's date.
+
+Astronomy primitives (night window, moon rise/set, sun altitude, moon
+separation/illumination, transit altitude, night hour-angle overlap):
+extracted from `hevelius/asteroid.py` (OS-3), which is the one place this
+math already existed and was battle-tested against ~1M rows. Behavior is
+unchanged for the asteroid-visibility feature; these are now importable
+elsewhere too - namely `hevelius/observability.py`, the generic staged
+visibility pipeline that Night Plan (OS-4) calls for tasks and projects.
 
 Shared by Night Plan (OS-4), `observation_events.night_date` (OS-8), and
 nightly Statistics grouping (OS-9) so all three consumers bucket
-observations into nights the same way. Pure function, no DB dependency:
-callers pass the telescope's IANA timezone name (`telescopes.timezone`,
-see OS-2) rather than a scope/telescope object.
+observations into nights the same way.
 """
 
 import datetime
+from typing import Tuple
 from zoneinfo import ZoneInfo
+
+import numpy as np
+from astropy.coordinates import AltAz, EarthLocation, SkyCoord, get_body, get_sun
+from astropy.time import Time
+from astropy import units as u
+from astropy.utils import iers
 
 
 def night_date(t: datetime.datetime, tz_name: str) -> datetime.date:
@@ -32,3 +45,230 @@ def night_date(t: datetime.datetime, tz_name: str) -> datetime.date:
 
     local = t.astimezone(ZoneInfo(tz_name))
     return (local - datetime.timedelta(hours=12)).date()
+
+
+def _configure_iers_for_planning() -> None:
+    """
+    Allow IERS age extrapolation for offline/future observation planning.
+
+    Recent/future dates need up-to-date Earth orientation (IERS) data, normally
+    auto-downloaded. Without network access (or if the download fails), astropy
+    raises rather than falling back to extrapolated values. The extrapolation
+    error is sub-arcsecond and irrelevant for altitude/visibility purposes, so
+    disable the hard age limit when running visibility computations.
+
+    Idempotent via the auto_max_age sentinel, so calling it from every public
+    function in this module does not repeatedly touch global astropy state.
+    """
+    if iers.conf.auto_max_age is None:
+        return
+    iers.conf.auto_max_age = None
+
+
+def _altitude_series(body_fn, location: EarthLocation, t0: Time, t1: Time, n: int = 481):
+    """
+    Sample altitude (degrees) of a solar-system body from t0 to t1 inclusive.
+
+    body_fn(times) -> SkyCoord (e.g. get_sun, or lambda t: get_body('moon', t)).
+    """
+    duration_h = (t1 - t0).to(u.hour).value
+    times = t0 + np.linspace(0.0, duration_h, n) * u.hour
+    frame = AltAz(obstime=times, location=location)
+    alt = body_fn(times).transform_to(frame).alt.to(u.deg).value
+    return times, np.asarray(alt, dtype=float)
+
+
+def _find_zero_crossings(times: Time, alts: np.ndarray, level: float = 0.0):
+    """
+    Linearly interpolate times where altitude crosses `level`.
+
+    Returns list of (Time, direction) with direction 'up' or 'down'.
+    """
+    crossings = []
+    for i in range(len(alts) - 1):
+        a0, a1 = alts[i] - level, alts[i + 1] - level
+        if a0 == 0:
+            # Exact hit: infer direction from the next sample when possible.
+            if a1 > 0:
+                crossings.append((times[i], "up"))
+            elif a1 < 0:
+                crossings.append((times[i], "down"))
+            continue
+        if a0 * a1 > 0:
+            continue
+        if a0 * a1 == 0 and a1 == 0:
+            continue
+        frac = abs(a0) / (abs(a0) + abs(a1) + 1e-20)
+        t_cross = times[i] + frac * (times[i + 1] - times[i])
+        crossings.append((t_cross, "up" if a1 > a0 else "down"))
+    return crossings
+
+
+def get_night_times(location: EarthLocation, obs_time: Time) -> Tuple[Time, Time]:
+    """
+    Return (sunset, sunrise) in UTC for the night beginning on obs_time's date.
+
+    The night runs from geometric sunset (sun altitude crossing 0° downward)
+    on the evening of that calendar date through geometric sunrise the next
+    morning. This matches observer "night" even when astronomical twilight
+    never occurs (e.g. mid-latitude summer).
+
+    If the Sun never sets (polar day), falls back to a 12-hour window centred
+    on local solar midnight as a last resort. If the Sun never rises (polar
+    night), returns noon→next-noon.
+    """
+    _configure_iers_for_planning()
+
+    # Search from noon UTC on the evening date through noon the next day.
+    date_str = obs_time.iso[:10]
+    noon = Time(f"{date_str} 12:00:00")
+    times, alts = _altitude_series(get_sun, location, noon, noon + 24 * u.hour, n=577)
+    crossings = _find_zero_crossings(times, alts, level=0.0)
+
+    sunset = next((t for t, d in crossings if d == "down"), None)
+    sunrise = None
+    if sunset is not None:
+        sunrise = next((t for t, d in crossings if d == "up" and t > sunset), None)
+
+    if sunset is not None and sunrise is not None and sunrise > sunset:
+        return sunset, sunrise
+
+    # Polar night: sun always below horizon across the window.
+    if np.all(alts < 0):
+        return noon, noon + 24 * u.hour
+
+    # Polar day / no clear night: last-resort evening-centred window (NOT daytime).
+    midnight = noon + 12 * u.hour
+    return midnight - 6 * u.hour, midnight + 6 * u.hour
+
+
+def moon_rise_set(location: EarthLocation, night_start: Time, night_end: Time):
+    """
+    Find moonrise/moonset near the given night.
+
+    Searches a padded window around the night so events just outside sunset/
+    sunrise are still reported. Returns (moonrise, moonset) as Time or None.
+    """
+    _configure_iers_for_planning()
+
+    pad = 6 * u.hour
+    times, alts = _altitude_series(
+        lambda t: get_body("moon", t),
+        location,
+        night_start - pad,
+        night_end + pad,
+        n=721,
+    )
+    crossings = _find_zero_crossings(times, alts, level=0.0)
+    rises = [t for t, d in crossings if d == "up"]
+    sets = [t for t, d in crossings if d == "down"]
+
+    moonrise = next((r for r in rises if r <= night_end + pad), None)
+    moonset = None
+    if moonrise is not None:
+        moonset = next((s for s in sets if s > moonrise), None)
+    elif sets:
+        # Moon already up at window start: report the upcoming set.
+        moonset = sets[0]
+
+    return moonrise, moonset
+
+
+def _moon_altitudes(location: EarthLocation, times: Time) -> np.ndarray:
+    """Moon altitude in degrees at each sample time."""
+    frame = AltAz(obstime=times, location=location)
+    return get_body("moon", times).transform_to(frame).alt.to(u.deg).value
+
+
+def sun_altitude_deg(time: Time, location: EarthLocation) -> float:
+    """Sun altitude in degrees (geometric, no refraction) at a given time/location."""
+    _configure_iers_for_planning()
+    frame = AltAz(obstime=time, location=location)
+    return float(get_sun(time).transform_to(frame).alt.to(u.deg).value)
+
+
+def moon_separation_deg(ra_deg: float, dec_deg: float, time: Time, location: EarthLocation) -> float:
+    """
+    Angular separation in degrees between a fixed sky position (ICRS RA/Dec,
+    in degrees) and the Moon, as seen from `location` at `time` (topocentric,
+    i.e. corrected for the observer's position - the Moon is close enough
+    that this matters for a "how close is the Moon" check).
+
+    Both positions are transformed to the same AltAz frame before comparing,
+    rather than calling `.separation()` directly across an ICRS (no
+    distance - a fixed sky target is conceptually at infinity) vs. GCRS
+    (Moon, a real ~384,000 km distance) pair: that mismatched-distance,
+    origin-shifting combination has been observed to produce wildly wrong
+    separations (tens of degrees) with this astropy version, apparently
+    because the "at infinity" ICRS point gets a spurious ~1 AU parallax
+    shift applied against the barycentre instead of being treated as
+    distance-independent. Comparing within one observer-centred frame
+    sidesteps the barycentric origin shift entirely.
+    """
+    _configure_iers_for_planning()
+    frame = AltAz(obstime=time, location=location)
+    target = SkyCoord(ra=ra_deg * u.deg, dec=dec_deg * u.deg, frame="icrs").transform_to(frame)
+    moon = get_body("moon", time, location=location).transform_to(frame)
+    return float(target.separation(moon).to(u.deg).value)
+
+
+def moon_illumination_pct(time: Time) -> float:
+    """
+    Approximate Moon illuminated fraction (0-100%) at `time`.
+
+    Derived from the Sun-Moon elongation as seen from Earth's centre, using
+    the standard small-body approximation phase_angle ≈ 180° − elongation
+    (exact for a Sun at infinite distance; the real Earth-Sun distance makes
+    this accurate to well under 1% illumination, adequate for a "is the moon
+    too bright" filter - the same tolerance asteroid.py already accepts for
+    magnitude/geometry at this pipeline stage). Geocentric, since the
+    illuminated fraction barely changes with observer location.
+    """
+    sun = get_sun(time)
+    moon = get_body("moon", time)
+    elongation = sun.separation(moon)
+    phase_angle = (180.0 * u.deg) - elongation
+    illuminated_fraction = (1.0 + np.cos(phase_angle.to(u.rad).value)) / 2.0
+    return float(np.clip(illuminated_fraction, 0.0, 1.0) * 100.0)
+
+
+def transit_altitude_deg(dec_deg: float, lat_deg: float) -> float:
+    """Maximum altitude an object ever reaches (at upper transit)."""
+    return 90.0 - abs(lat_deg - dec_deg)
+
+
+def ha_window_visible(ra_deg: float, dec_deg: float, lat_deg: float,
+                      lst_mid_deg: float, night_half_h: float,
+                      alt_min_deg: float) -> bool:
+    """
+    Quick test: is the object above alt_min at any moment during the night?
+
+    Uses hour-angle arithmetic to determine whether the window in which the
+    object is above alt_min overlaps with the night window (centred on
+    local midnight, i.e. `night_half_h` hours either side of `lst_mid_deg`).
+    """
+    lat = np.radians(lat_deg)
+    dec = np.radians(dec_deg)
+    alt_min = np.radians(alt_min_deg)
+
+    sin_alt_transit = np.sin(dec) * np.sin(lat) + np.cos(dec) * np.cos(lat)
+    if sin_alt_transit < np.sin(alt_min):
+        return False
+
+    cos_ha_thresh = (np.sin(alt_min) - np.sin(dec) * np.sin(lat)) / (
+        np.cos(dec) * np.cos(lat) + 1e-12
+    )
+
+    lst_half_deg = night_half_h * 15.0
+
+    if cos_ha_thresh <= -1.0:
+        return True  # circumpolar above alt_min
+
+    if cos_ha_thresh >= 1.0:
+        return False  # never reaches alt_min
+
+    ha_thresh_deg = np.degrees(np.arccos(cos_ha_thresh))
+
+    # Angular separation between object RA and LST at midnight
+    center_sep = abs(((ra_deg - lst_mid_deg) + 180.0) % 360.0 - 180.0)
+    return bool(center_sep < (ha_thresh_deg + lst_half_deg))

--- a/hevelius/observability.py
+++ b/hevelius/observability.py
@@ -106,6 +106,12 @@ class VisibilityResult:
     moon_illumination_pct: Optional[float] = None
 
 
+def _transit_offset_h(ra_deg: float, lst_mid_deg: float) -> float:
+    """Hours from night midpoint to upper transit (negative = transit before midnight)."""
+    ha_mid_deg = ((lst_mid_deg - ra_deg) + 180.0) % 360.0 - 180.0
+    return -ha_mid_deg / 15.0
+
+
 def _representative_check_time(
     ra_deg: float, lst_mid_deg: float, t_mid: Time, night_half_h: float,
 ) -> Time:
@@ -114,11 +120,35 @@ def _representative_check_time(
     astronomical midnight (§4.2). Fixed RA/Dec means the transit time is a
     direct hour-angle computation - no orbit propagation needed.
     """
-    ha_mid_deg = ((lst_mid_deg - ra_deg) + 180.0) % 360.0 - 180.0
-    transit_offset_h = -ha_mid_deg / 15.0
+    transit_offset_h = _transit_offset_h(ra_deg, lst_mid_deg)
     if abs(transit_offset_h) <= night_half_h:
         return t_mid + transit_offset_h * u.hour
     return t_mid
+
+
+def _altitude_check_time(
+    ra_deg: float,
+    lst_mid_deg: float,
+    t_mid: Time,
+    night_half_h: float,
+    night_start: Time,
+    night_end: Time,
+) -> Time:
+    """
+    Moment within the night when the target is highest (stage 5).
+
+    Fixed RA/Dec peaks at transit. When transit falls inside the night use
+    it; when transit is before sunset the target is descending so sunset is
+    best; when transit is after sunrise the target is still rising so sunrise
+    is best. This avoids rejecting evening/morning targets that stage 3
+    already confirmed overlap with the above-min_alt window.
+    """
+    transit_offset_h = _transit_offset_h(ra_deg, lst_mid_deg)
+    if abs(transit_offset_h) <= night_half_h:
+        return t_mid + transit_offset_h * u.hour
+    if transit_offset_h < -night_half_h:
+        return night_start
+    return night_end
 
 
 def check_visibility(
@@ -180,22 +210,25 @@ def check_visibility(
         )
 
     # Stage 5: precise astropy ICRS -> AltAz confirm, survivors only.
+    t_alt = _altitude_check_time(
+        ra_deg, lst_mid_deg, t_mid, night_half_h, night_start, night_end,
+    )
     target = SkyCoord(ra=ra_deg * u.deg, dec=dec_deg * u.deg, frame="icrs")
-    altaz = target.transform_to(AltAz(obstime=t_check, location=location))
+    altaz = target.transform_to(AltAz(obstime=t_alt, location=location))
     alt_deg = float(altaz.alt.to(u.deg).value)
     az_deg = float(altaz.az.to(u.deg).value)
 
     if alt_deg < min_alt:
         return VisibilityResult(
             visible=False, reason=REASON_BELOW_MIN_ALTITUDE,
-            check_time=t_check, altitude_deg=round(alt_deg, 2), azimuth_deg=round(az_deg, 2),
+            check_time=t_alt, altitude_deg=round(alt_deg, 2), azimuth_deg=round(az_deg, 2),
             sun_altitude_deg=round(sun_alt, 2), moon_separation_deg=round(moon_sep, 2),
             moon_illumination_pct=round(moon_illum, 2),
         )
 
     return VisibilityResult(
         visible=True,
-        check_time=t_check,
+        check_time=t_alt,
         altitude_deg=round(alt_deg, 2),
         azimuth_deg=round(az_deg, 2),
         sun_altitude_deg=round(sun_alt, 2),

--- a/hevelius/observability.py
+++ b/hevelius/observability.py
@@ -25,8 +25,9 @@ Unlike `asteroid.py`'s moving targets (which need one Kepler-orbit solve
 per check time), tasks and projects have fixed RA/Dec, so the "check
 moment" here is derived directly from the target's transit time rather
 than refined iteratively: the transit time if it falls inside the night
-window, else astronomical midnight (§4.2 of
-`doc/observation-scheduler-plan.md`).
+window, else whichever edge of the night (sunset or sunrise) is closest
+to transit, for targets only above the horizon near one edge of the
+night (§4.2 of `doc/observation-scheduler-plan.md`).
 """
 
 from dataclasses import dataclass
@@ -113,20 +114,6 @@ def _transit_offset_h(ra_deg: float, lst_mid_deg: float) -> float:
 
 
 def _representative_check_time(
-    ra_deg: float, lst_mid_deg: float, t_mid: Time, night_half_h: float,
-) -> Time:
-    """
-    Check moment = transit time if it falls inside the night window, else
-    astronomical midnight (§4.2). Fixed RA/Dec means the transit time is a
-    direct hour-angle computation - no orbit propagation needed.
-    """
-    transit_offset_h = _transit_offset_h(ra_deg, lst_mid_deg)
-    if abs(transit_offset_h) <= night_half_h:
-        return t_mid + transit_offset_h * u.hour
-    return t_mid
-
-
-def _altitude_check_time(
     ra_deg: float,
     lst_mid_deg: float,
     t_mid: Time,
@@ -135,13 +122,21 @@ def _altitude_check_time(
     night_end: Time,
 ) -> Time:
     """
-    Moment within the night when the target is highest (stage 5).
+    Moment within the night to run stages 4 and 5 against: transit time if
+    it falls inside the night window (fixed RA/Dec means that's a direct
+    hour-angle computation, no orbit propagation needed); otherwise the
+    target is only above the horizon near one edge of the night, so use
+    whichever edge is closest to its transit - sunset if transit is before
+    the night starts (the target is already descending all night), sunrise
+    if transit is after the night ends (still rising all night).
 
-    Fixed RA/Dec peaks at transit. When transit falls inside the night use
-    it; when transit is before sunset the target is descending so sunset is
-    best; when transit is after sunrise the target is still rising so sunrise
-    is best. This avoids rejecting evening/morning targets that stage 3
-    already confirmed overlap with the above-min_alt window.
+    Using astronomical midnight here for an evening-only or morning-only
+    target would check sun/moon conditions and altitude at a moment the
+    target isn't even above `min_alt` (stage 3 only confirmed *some* moment
+    in the night qualifies, not that midnight is it), which can both
+    wrongly reject the target (stage 5) and wrongly evaluate sun/moon
+    constraints against a moment the target was never observable at
+    (stage 4).
     """
     transit_offset_h = _transit_offset_h(ra_deg, lst_mid_deg)
     if abs(transit_offset_h) <= night_half_h:
@@ -183,7 +178,9 @@ def check_visibility(
     if not night.ha_window_visible(ra_deg, dec_deg, lat_deg, lst_mid_deg, night_half_h, min_alt):
         return VisibilityResult(visible=False, reason=REASON_BELOW_MIN_ALTITUDE)
 
-    t_check = _representative_check_time(ra_deg, lst_mid_deg, t_mid, night_half_h)
+    t_check = _representative_check_time(
+        ra_deg, lst_mid_deg, t_mid, night_half_h, night_start, night_end,
+    )
 
     # Stage 4: representative-moment check (sun altitude, moon separation/phase).
     sun_alt = night.sun_altitude_deg(t_check, location)
@@ -210,25 +207,22 @@ def check_visibility(
         )
 
     # Stage 5: precise astropy ICRS -> AltAz confirm, survivors only.
-    t_alt = _altitude_check_time(
-        ra_deg, lst_mid_deg, t_mid, night_half_h, night_start, night_end,
-    )
     target = SkyCoord(ra=ra_deg * u.deg, dec=dec_deg * u.deg, frame="icrs")
-    altaz = target.transform_to(AltAz(obstime=t_alt, location=location))
+    altaz = target.transform_to(AltAz(obstime=t_check, location=location))
     alt_deg = float(altaz.alt.to(u.deg).value)
     az_deg = float(altaz.az.to(u.deg).value)
 
     if alt_deg < min_alt:
         return VisibilityResult(
             visible=False, reason=REASON_BELOW_MIN_ALTITUDE,
-            check_time=t_alt, altitude_deg=round(alt_deg, 2), azimuth_deg=round(az_deg, 2),
+            check_time=t_check, altitude_deg=round(alt_deg, 2), azimuth_deg=round(az_deg, 2),
             sun_altitude_deg=round(sun_alt, 2), moon_separation_deg=round(moon_sep, 2),
             moon_illumination_pct=round(moon_illum, 2),
         )
 
     return VisibilityResult(
         visible=True,
-        check_time=t_alt,
+        check_time=t_check,
         altitude_deg=round(alt_deg, 2),
         azimuth_deg=round(az_deg, 2),
         sun_altitude_deg=round(sun_alt, 2),

--- a/hevelius/observability.py
+++ b/hevelius/observability.py
@@ -1,0 +1,204 @@
+"""
+Generic target-visibility engine (OS-3).
+
+Answers "is this RA/Dec target visible tonight, and roughly when" for a
+single target with fixed sky coordinates. This is the shared engine Night
+Plan (OS-4, #46) calls for both tasks and projects, deliberately generic
+over `(ra_deg, dec_deg, constraints)` rather than task/project-specific:
+callers do their own table-specific SQL pre-filtering (scope match,
+state/date window, mount `min_dec`/`max_dec` - stage 1 below) before
+calling in here, so this module doesn't need to know about `tasks` or
+`projects` at all.
+
+Reuses the same cheap-filters-first structure `hevelius asteroid visible`
+(`hevelius/asteroid.py`) already uses against ~1M rows, staged so that
+expensive checks only ever run on survivors of the cheap ones:
+
+  1. SQL pre-filter (scope match, state/date window, mount min_dec/max_dec)
+     - caller's responsibility, not implemented here (table-specific).
+  2. Transit-altitude check (one subtraction).
+  3. Night hour-angle overlap (trig, no frame transform).
+  4. Representative-moment check (sun altitude, moon separation/phase).
+  5. Precise astropy GCRS/ICRS -> AltAz confirm, survivors only.
+
+Unlike `asteroid.py`'s moving targets (which need one Kepler-orbit solve
+per check time), tasks and projects have fixed RA/Dec, so the "check
+moment" here is derived directly from the target's transit time rather
+than refined iteratively: the transit time if it falls inside the night
+window, else astronomical midnight (§4.2 of
+`doc/observation-scheduler-plan.md`).
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from astropy.coordinates import AltAz, EarthLocation, SkyCoord
+from astropy.time import Time
+from astropy import units as u
+
+from hevelius import night
+
+# Fallback altitude floor (degrees) when a target has no min_alt constraint
+# set (tasks.min_alt / projects.min_alt are nullable - see OS-2). Matches
+# the default hevelius/asteroid.py's own `compute_visibility` uses, so an
+# unconstrained target isn't silently treated as visible all the way down
+# to the mathematical horizon.
+DEFAULT_MIN_ALT_DEG = 20.0
+
+# Exclusion reason codes, matching doc/observation-scheduler-plan.md §4.3
+# ("explain mode"). `outside_mount_dec_range`, `outside_date_window`,
+# `filter_not_on_scope`, `already_complete`, `wrong_state` and
+# `min_interval_not_elapsed` are stage-1 (SQL pre-filter) concerns owned by
+# the caller, not raised here.
+REASON_BELOW_MIN_ALTITUDE = "below_min_altitude"
+REASON_SUN_TOO_HIGH = "sun_too_high"
+REASON_MOON_TOO_CLOSE = "moon_too_close"
+REASON_MOON_PHASE_TOO_BRIGHT = "moon_phase_too_bright"
+
+
+def ra_hours_to_deg(ra_hours: float) -> float:
+    """
+    Convert `tasks.ra`/`projects.ra` (stored in hours, 0-24) to the degrees
+    (0-360) this module and `hevelius/asteroid.py` work in.
+
+    This is the one boundary conversion the whole engine depends on getting
+    right (§1.2 of the plan doc): mixing up hours and degrees silently
+    mis-places every target by a factor of 15 rather than raising an
+    out-of-range error you'd notice immediately.
+    """
+    return ra_hours * 15.0
+
+
+@dataclass
+class Constraints:
+    """
+    Observing constraints for one target, mirroring the `tasks`/`projects`
+    columns added in OS-2. All fields are optional/nullable, matching the
+    DB columns: `None` means "no constraint of this kind" - except
+    `min_alt`, which always falls back to `DEFAULT_MIN_ALT_DEG` (see its
+    docstring), since "no altitude floor at all" is never physically
+    meaningful.
+    """
+    min_alt: Optional[float] = None
+    moon_distance: Optional[float] = None
+    max_moon_phase: Optional[float] = None
+    max_sun_alt: Optional[float] = None
+
+
+@dataclass
+class VisibilityResult:
+    """
+    Outcome of `check_visibility` for one target.
+
+    `reason` is `None` when `visible` is True. Diagnostic fields
+    (`sun_altitude_deg`, `moon_separation_deg`, `moon_illumination_pct`) are
+    populated as far as the staged pipeline got before a rejection (or all
+    the way through, when visible) - useful for `?explain=true` (OS-4)
+    without recomputing anything.
+    """
+    visible: bool
+    reason: Optional[str] = None
+    check_time: Optional[Time] = None
+    altitude_deg: Optional[float] = None
+    azimuth_deg: Optional[float] = None
+    sun_altitude_deg: Optional[float] = None
+    moon_separation_deg: Optional[float] = None
+    moon_illumination_pct: Optional[float] = None
+
+
+def _representative_check_time(
+    ra_deg: float, lst_mid_deg: float, t_mid: Time, night_half_h: float,
+) -> Time:
+    """
+    Check moment = transit time if it falls inside the night window, else
+    astronomical midnight (§4.2). Fixed RA/Dec means the transit time is a
+    direct hour-angle computation - no orbit propagation needed.
+    """
+    ha_mid_deg = ((lst_mid_deg - ra_deg) + 180.0) % 360.0 - 180.0
+    transit_offset_h = -ha_mid_deg / 15.0
+    if abs(transit_offset_h) <= night_half_h:
+        return t_mid + transit_offset_h * u.hour
+    return t_mid
+
+
+def check_visibility(
+    ra_deg: float,
+    dec_deg: float,
+    constraints: Constraints,
+    location: EarthLocation,
+    night_start: Time,
+    night_end: Time,
+) -> VisibilityResult:
+    """
+    Run the stage 2-5 visibility pipeline for one fixed-RA/Dec target.
+
+    `night_start`/`night_end` are the actual sunset/sunrise window (e.g.
+    from `hevelius.night.get_night_times`), not the coarser night-identity
+    window from `night_date`.
+    """
+    night._configure_iers_for_planning()
+
+    min_alt = constraints.min_alt if constraints.min_alt is not None else DEFAULT_MIN_ALT_DEG
+    lat_deg = location.lat.deg
+
+    # Stage 2: transit-altitude check (one subtraction).
+    transit_alt = night.transit_altitude_deg(dec_deg, lat_deg)
+    if transit_alt < min_alt:
+        return VisibilityResult(visible=False, reason=REASON_BELOW_MIN_ALTITUDE)
+
+    # Stage 3: night hour-angle overlap (trig, no frame transform).
+    night_half_h = (night_end - night_start).to(u.hour).value / 2.0
+    t_mid = night_start + night_half_h * u.hour
+    lst_mid_deg = t_mid.sidereal_time("apparent", longitude=location.lon).deg
+    if not night.ha_window_visible(ra_deg, dec_deg, lat_deg, lst_mid_deg, night_half_h, min_alt):
+        return VisibilityResult(visible=False, reason=REASON_BELOW_MIN_ALTITUDE)
+
+    t_check = _representative_check_time(ra_deg, lst_mid_deg, t_mid, night_half_h)
+
+    # Stage 4: representative-moment check (sun altitude, moon separation/phase).
+    sun_alt = night.sun_altitude_deg(t_check, location)
+    if constraints.max_sun_alt is not None and sun_alt > constraints.max_sun_alt:
+        return VisibilityResult(
+            visible=False, reason=REASON_SUN_TOO_HIGH,
+            check_time=t_check, sun_altitude_deg=round(sun_alt, 2),
+        )
+
+    moon_sep = night.moon_separation_deg(ra_deg, dec_deg, t_check, location)
+    if constraints.moon_distance is not None and moon_sep < constraints.moon_distance:
+        return VisibilityResult(
+            visible=False, reason=REASON_MOON_TOO_CLOSE,
+            check_time=t_check, sun_altitude_deg=round(sun_alt, 2),
+            moon_separation_deg=round(moon_sep, 2),
+        )
+
+    moon_illum = night.moon_illumination_pct(t_check)
+    if constraints.max_moon_phase is not None and moon_illum > constraints.max_moon_phase:
+        return VisibilityResult(
+            visible=False, reason=REASON_MOON_PHASE_TOO_BRIGHT,
+            check_time=t_check, sun_altitude_deg=round(sun_alt, 2),
+            moon_separation_deg=round(moon_sep, 2), moon_illumination_pct=round(moon_illum, 2),
+        )
+
+    # Stage 5: precise astropy ICRS -> AltAz confirm, survivors only.
+    target = SkyCoord(ra=ra_deg * u.deg, dec=dec_deg * u.deg, frame="icrs")
+    altaz = target.transform_to(AltAz(obstime=t_check, location=location))
+    alt_deg = float(altaz.alt.to(u.deg).value)
+    az_deg = float(altaz.az.to(u.deg).value)
+
+    if alt_deg < min_alt:
+        return VisibilityResult(
+            visible=False, reason=REASON_BELOW_MIN_ALTITUDE,
+            check_time=t_check, altitude_deg=round(alt_deg, 2), azimuth_deg=round(az_deg, 2),
+            sun_altitude_deg=round(sun_alt, 2), moon_separation_deg=round(moon_sep, 2),
+            moon_illumination_pct=round(moon_illum, 2),
+        )
+
+    return VisibilityResult(
+        visible=True,
+        check_time=t_check,
+        altitude_deg=round(alt_deg, 2),
+        azimuth_deg=round(az_deg, 2),
+        sun_altitude_deg=round(sun_alt, 2),
+        moon_separation_deg=round(moon_sep, 2),
+        moon_illumination_pct=round(moon_illum, 2),
+    )

--- a/tests/test_asteroid_show.py
+++ b/tests/test_asteroid_show.py
@@ -7,7 +7,7 @@ from argparse import Namespace
 from contextlib import redirect_stdout
 
 from tests.dbtest import use_repository
-from hevelius import db, asteroid
+from hevelius import db, asteroid, night
 
 
 class TestAsteroidNameLookup(unittest.TestCase):
@@ -136,7 +136,7 @@ class TestNightWindow(unittest.TestCase):
         from astropy import units as u
 
         loc = EarthLocation(lat=52.2 * u.deg, lon=21.0 * u.deg, height=100 * u.m)
-        start, end = asteroid._get_night_times(loc, Time("2026-07-22 00:00:00"))
+        start, end = night.get_night_times(loc, Time("2026-07-22 00:00:00"))
         self.assertLess(start, end)
         # Must cross midnight and start in the evening (not the old 06:00–18:00 fallback)
         self.assertNotEqual(start.iso[:10], end.iso[:10])

--- a/tests/test_cmd_asteroid2.py
+++ b/tests/test_cmd_asteroid2.py
@@ -5,7 +5,7 @@ import unittest
 from astropy.coordinates import EarthLocation
 from astropy import units as u
 
-from hevelius import asteroid
+from hevelius import asteroid, night
 
 
 def _mpcorb_line(designation: str, H: str = " 3.34", G: str = " 0.15",
@@ -169,11 +169,11 @@ class TestVisibilityCurve(unittest.TestCase):
 
 class TestIersConfigLazy(unittest.TestCase):
     def test_import_does_not_require_prior_iers_config(self):
-        # Visibility entry points call _configure_iers_for_planning(); the
-        # helper is idempotent and safe to call again.
-        asteroid._configure_iers_for_planning()
-        asteroid._configure_iers_for_planning()
-        self.assertIsNone(asteroid.iers.conf.auto_max_age)
+        # Visibility entry points call night._configure_iers_for_planning();
+        # the helper is idempotent and safe to call again.
+        night._configure_iers_for_planning()
+        night._configure_iers_for_planning()
+        self.assertIsNone(night.iers.conf.auto_max_age)
 
 
 if __name__ == "__main__":

--- a/tests/test_night.py
+++ b/tests/test_night.py
@@ -1,11 +1,20 @@
 """
-Tests hevelius.night.night_date() - the NINA "date - 12h" night identity rule.
+Tests hevelius.night: the NINA "date - 12h" night identity rule
+(night_date), plus the OS-3 astronomy primitives extracted from
+hevelius/asteroid.py (get_night_times, moon_rise_set, transit_altitude_deg,
+ha_window_visible) and the new sun/moon helpers
+(sun_altitude_deg, moon_separation_deg, moon_illumination_pct).
 """
 
 import datetime
 
+import numpy as np
 import pytest
+from astropy.coordinates import EarthLocation, get_body, get_sun
+from astropy.time import Time
+from astropy import units as u
 
+from hevelius import night
 from hevelius.night import night_date
 
 WARSAW = "Europe/Warsaw"
@@ -56,3 +65,133 @@ def test_night_date_utc_site():
     """A telescope with tz_name='UTC' just applies the -12h rule directly."""
     utc_time = datetime.datetime(2026, 8, 3, 20, 0, 0, tzinfo=UTC)
     assert night_date(utc_time, "UTC") == datetime.date(2026, 8, 3)
+
+
+# --- OS-3 primitives ---------------------------------------------------
+
+SITE = EarthLocation(lat=52.2 * u.deg, lon=21.0 * u.deg, height=100 * u.m)
+
+
+class TestTransitAltitudeDeg:
+    def test_matches_90_minus_abs_lat_minus_dec(self):
+        assert night.transit_altitude_deg(dec_deg=10.0, lat_deg=52.2) == pytest.approx(47.8)
+        assert night.transit_altitude_deg(dec_deg=52.2, lat_deg=52.2) == pytest.approx(90.0)
+        assert night.transit_altitude_deg(dec_deg=-37.8, lat_deg=52.2) == pytest.approx(0.0)
+
+
+class TestHaWindowVisible:
+    def test_circumpolar_object_always_visible_regardless_of_ra(self):
+        # dec close to the pole at a mid-northern latitude: never sets below
+        # alt_min=0, so the RA vs LST relationship doesn't matter.
+        assert night.ha_window_visible(
+            ra_deg=0.0, dec_deg=89.9, lat_deg=52.2,
+            lst_mid_deg=180.0, night_half_h=4.0, alt_min_deg=0.0,
+        ) is True
+
+    def test_object_that_never_rises_above_alt_min(self):
+        # dec far enough south of the horizon at this latitude that even
+        # transit altitude is negative: never visible, any RA/LST.
+        assert night.ha_window_visible(
+            ra_deg=0.0, dec_deg=-89.9, lat_deg=52.2,
+            lst_mid_deg=180.0, night_half_h=4.0, alt_min_deg=0.0,
+        ) is False
+
+    def test_transit_at_midnight_is_visible_within_narrow_window(self):
+        # dec == lat: zenith (90 deg) at transit. RA == LST at midnight, so
+        # the object transits exactly at the centre of the night window.
+        assert night.ha_window_visible(
+            ra_deg=100.0, dec_deg=52.2, lat_deg=52.2,
+            lst_mid_deg=100.0, night_half_h=1.0, alt_min_deg=70.0,
+        ) is True
+
+    def test_transit_far_from_night_window_is_not_visible(self):
+        # Same dec/alt_min (visibility window is +-~33 deg of HA around
+        # transit), but the object's transit is 100 deg of HA away from a
+        # narrow (+-15 deg) night window: no overlap.
+        assert night.ha_window_visible(
+            ra_deg=200.0, dec_deg=52.2, lat_deg=52.2,
+            lst_mid_deg=100.0, night_half_h=1.0, alt_min_deg=70.0,
+        ) is False
+
+
+class TestGetNightTimes:
+    def test_night_window_brackets_sunset_to_sunrise(self):
+        start, end = night.get_night_times(SITE, Time("2026-07-22 00:00:00"))
+        assert start < end
+        # Evening-to-morning, not the old daytime fallback.
+        assert start.iso[:10] != end.iso[:10]
+        assert int(start.iso[11:13]) >= 15
+        assert int(end.iso[11:13]) < 8
+
+
+class TestMoonRiseSet:
+    def test_returns_times_within_padded_window(self):
+        night_start, night_end = night.get_night_times(SITE, Time("2026-07-22 00:00:00"))
+        moonrise, moonset = night.moon_rise_set(SITE, night_start, night_end)
+        pad = 6 * u.hour
+        if moonrise is not None:
+            assert night_start - pad <= moonrise <= night_end + pad
+        if moonset is not None:
+            assert night_start - pad <= moonset <= night_end + pad
+
+
+class TestSunAltitudeDeg:
+    def test_near_zero_at_geometric_sunset(self):
+        sunset, _sunrise = night.get_night_times(SITE, Time("2026-07-22 00:00:00"))
+        assert night.sun_altitude_deg(sunset, SITE) == pytest.approx(0.0, abs=0.1)
+
+    def test_negative_in_the_middle_of_the_night(self):
+        sunset, sunrise = night.get_night_times(SITE, Time("2026-07-22 00:00:00"))
+        midpoint = sunset + (sunrise - sunset) / 2
+        assert night.sun_altitude_deg(midpoint, SITE) < -5.0
+
+    def test_positive_around_local_midday(self):
+        # lon=21E -> local solar noon is roughly UTC 10:40; well within
+        # daytime in July at this latitude.
+        assert night.sun_altitude_deg(Time("2026-07-22 11:00:00"), SITE) > 10.0
+
+
+class TestMoonSeparationDeg:
+    def test_zero_at_the_moons_own_position(self):
+        t = Time("2026-07-22 22:00:00")
+        moon = get_body("moon", t, location=SITE)
+        sep = night.moon_separation_deg(moon.ra.deg, moon.dec.deg, t, SITE)
+        assert sep == pytest.approx(0.0, abs=0.05)
+
+    def test_maximal_at_the_antipodal_point(self):
+        t = Time("2026-07-22 22:00:00")
+        moon = get_body("moon", t, location=SITE)
+        anti_ra = (moon.ra.deg + 180.0) % 360.0
+        anti_dec = -moon.dec.deg
+        sep = night.moon_separation_deg(anti_ra, anti_dec, t, SITE)
+        assert sep > 170.0
+
+
+class TestMoonIlluminationPct:
+    def test_matches_elongation_based_formula(self):
+        t = Time("2026-07-22 22:00:00")
+        sun = get_sun(t)
+        moon = get_body("moon", t)
+        elongation = sun.separation(moon)
+        phase_angle = (180.0 * u.deg) - elongation
+        expected = float(np.clip((1.0 + np.cos(phase_angle.to(u.rad).value)) / 2.0, 0.0, 1.0) * 100.0)
+        assert night.moon_illumination_pct(t) == pytest.approx(expected, abs=1e-6)
+
+    def test_bounded_between_0_and_100(self):
+        for day in range(0, 28, 4):  # sample across roughly one lunar month
+            t = Time("2026-07-01 00:00:00") + day * u.day
+            pct = night.moon_illumination_pct(t)
+            assert 0.0 <= pct <= 100.0
+
+    def test_higher_elongation_gives_higher_illumination(self):
+        t1 = Time("2026-07-22 22:00:00")
+        t2 = Time("2026-07-30 22:00:00")
+        e1 = get_sun(t1).separation(get_body("moon", t1)).deg
+        e2 = get_sun(t2).separation(get_body("moon", t2)).deg
+        v1 = night.moon_illumination_pct(t1)
+        v2 = night.moon_illumination_pct(t2)
+        assert e1 != pytest.approx(e2, abs=1.0)  # sanity: dates actually differ in phase
+        if e1 > e2:
+            assert v1 > v2
+        else:
+            assert v2 > v1

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -105,3 +105,39 @@ class TestCheckVisibilityStaging:
         )
         assert result.visible is True
         assert result.reason is None
+
+    def test_evening_target_visible_when_above_min_alt_at_sunset_not_at_midnight(self):
+        # Transit is before the night window: stage 3 overlap passes, but altitude
+        # at night midpoint is below min_alt. Stage 5 must check at sunset.
+        evening_transit_ra = 124.4
+        night_half_h = (NIGHT_END - NIGHT_START).to(u.hour).value / 2.0
+        assert night.ha_window_visible(
+            evening_transit_ra, ZENITH_DEC, SITE.lat.deg, _LST_MID_DEG,
+            night_half_h, observability.DEFAULT_MIN_ALT_DEG,
+        )
+        result = observability.check_visibility(
+            ra_deg=evening_transit_ra, dec_deg=ZENITH_DEC, constraints=Constraints(),
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is True
+        assert result.reason is None
+        assert result.altitude_deg >= observability.DEFAULT_MIN_ALT_DEG
+        assert result.check_time == NIGHT_START
+
+    def test_morning_target_visible_when_above_min_alt_at_sunrise_not_at_midnight(self):
+        # Transit is after the night window: stage 3 overlap passes, but altitude
+        # at night midpoint is below min_alt. Stage 5 must check at sunrise.
+        morning_transit_ra = 82.4
+        night_half_h = (NIGHT_END - NIGHT_START).to(u.hour).value / 2.0
+        assert night.ha_window_visible(
+            morning_transit_ra, ZENITH_DEC, SITE.lat.deg, _LST_MID_DEG,
+            night_half_h, observability.DEFAULT_MIN_ALT_DEG,
+        )
+        result = observability.check_visibility(
+            ra_deg=morning_transit_ra, dec_deg=ZENITH_DEC, constraints=Constraints(),
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is True
+        assert result.reason is None
+        assert result.altitude_deg >= observability.DEFAULT_MIN_ALT_DEG
+        assert result.check_time == NIGHT_END

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,107 @@
+"""
+Tests hevelius.observability: the generic (ra_deg, dec_deg, constraints)
+staged visibility pipeline (OS-3) that Night Plan (OS-4, #46) will call for
+tasks and projects.
+"""
+
+from astropy.coordinates import EarthLocation
+from astropy.time import Time
+from astropy import units as u
+
+from hevelius import night, observability
+from hevelius.observability import Constraints
+
+SITE = EarthLocation(lat=52.2 * u.deg, lon=21.0 * u.deg, height=100 * u.m)
+NIGHT_START, NIGHT_END = night.get_night_times(SITE, Time("2026-07-22 00:00:00"))
+_T_MID = NIGHT_START + (NIGHT_END - NIGHT_START) / 2
+_LST_MID_DEG = _T_MID.sidereal_time("apparent", longitude=SITE.lon).deg
+
+# A target with dec == site latitude transits at the zenith; RA == LST at
+# midnight makes it transit exactly at the centre of the night window, so
+# it's comfortably visible under permissive constraints.
+ZENITH_DEC = SITE.lat.deg
+MIDNIGHT_TRANSIT_RA = _LST_MID_DEG
+
+
+class TestRaHoursToDeg:
+    """§1.2: the RA hours->degrees boundary conversion, guarded on its own."""
+
+    def test_conversion_factor_of_15(self):
+        assert observability.ra_hours_to_deg(0.0) == 0.0
+        assert observability.ra_hours_to_deg(1.0) == 15.0
+        assert observability.ra_hours_to_deg(12.0) == 180.0
+
+    def test_full_range_maps_onto_full_circle(self):
+        # tasks.ra / projects.ra are validated 0-24h (TaskAddRequestSchema);
+        # confirm that range maps onto the full 0-360 degree circle used by
+        # this module and hevelius/asteroid.py.
+        assert observability.ra_hours_to_deg(0.0) == 0.0
+        assert observability.ra_hours_to_deg(24.0) == 360.0
+
+
+class TestCheckVisibilityStaging:
+    def test_below_min_altitude_short_circuits_before_any_sun_moon_check(self):
+        # Transit altitude alone (90 - |lat - dec|) already rules this out
+        # at a mid-northern latitude: stage 2 rejects before stage 3/4/5 run.
+        result = observability.check_visibility(
+            ra_deg=0.0, dec_deg=-80.0, constraints=Constraints(),
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is False
+        assert result.reason == observability.REASON_BELOW_MIN_ALTITUDE
+        assert result.check_time is None  # rejected before stage 3
+
+    def test_visible_target_with_no_constraints_beyond_default_min_alt(self):
+        result = observability.check_visibility(
+            ra_deg=MIDNIGHT_TRANSIT_RA, dec_deg=ZENITH_DEC, constraints=Constraints(),
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is True
+        assert result.reason is None
+        assert result.altitude_deg > observability.DEFAULT_MIN_ALT_DEG
+        assert result.azimuth_deg is not None
+        assert result.sun_altitude_deg < 0  # it's nighttime
+        assert result.moon_separation_deg is not None
+        assert result.moon_illumination_pct is not None
+
+    def test_sun_too_high_rejects_when_constraint_stricter_than_actual(self):
+        actual_sun_alt = night.sun_altitude_deg(_T_MID, SITE)
+        constraints = Constraints(max_sun_alt=actual_sun_alt - 5.0)
+        result = observability.check_visibility(
+            ra_deg=MIDNIGHT_TRANSIT_RA, dec_deg=ZENITH_DEC, constraints=constraints,
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is False
+        assert result.reason == observability.REASON_SUN_TOO_HIGH
+        assert result.sun_altitude_deg is not None
+
+    def test_moon_too_close_rejects_when_constraint_stricter_than_actual(self):
+        actual_sep = night.moon_separation_deg(MIDNIGHT_TRANSIT_RA, ZENITH_DEC, _T_MID, SITE)
+        constraints = Constraints(moon_distance=actual_sep + 10.0)
+        result = observability.check_visibility(
+            ra_deg=MIDNIGHT_TRANSIT_RA, dec_deg=ZENITH_DEC, constraints=constraints,
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is False
+        assert result.reason == observability.REASON_MOON_TOO_CLOSE
+        assert result.moon_separation_deg is not None
+
+    def test_moon_phase_too_bright_rejects_when_constraint_stricter_than_actual(self):
+        actual_illum = night.moon_illumination_pct(_T_MID)
+        constraints = Constraints(max_moon_phase=actual_illum - 1.0)
+        result = observability.check_visibility(
+            ra_deg=MIDNIGHT_TRANSIT_RA, dec_deg=ZENITH_DEC, constraints=constraints,
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is False
+        assert result.reason == observability.REASON_MOON_PHASE_TOO_BRIGHT
+        assert result.moon_illumination_pct is not None
+
+    def test_permissive_constraints_pass_all_stages(self):
+        constraints = Constraints(min_alt=10.0, moon_distance=0.0, max_moon_phase=100.0, max_sun_alt=90.0)
+        result = observability.check_visibility(
+            ra_deg=MIDNIGHT_TRANSIT_RA, dec_deg=ZENITH_DEC, constraints=constraints,
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is True
+        assert result.reason is None

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -4,6 +4,7 @@ staged visibility pipeline (OS-3) that Night Plan (OS-4, #46) will call for
 tasks and projects.
 """
 
+import pytest
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
 from astropy import units as u
@@ -141,3 +142,39 @@ class TestCheckVisibilityStaging:
         assert result.reason is None
         assert result.altitude_deg >= observability.DEFAULT_MIN_ALT_DEG
         assert result.check_time == NIGHT_END
+
+    def test_evening_target_sun_check_runs_at_sunset_not_midnight(self):
+        # Same evening-only target as above. At sunset the Sun is at ~0 deg;
+        # at midnight it's the night's most negative. A max_sun_alt constraint
+        # that only the midnight value would satisfy must still reject here,
+        # since sunset - not midnight - is the only moment this target is up.
+        evening_transit_ra = 124.4
+        sun_alt_at_sunset = night.sun_altitude_deg(NIGHT_START, SITE)
+        sun_alt_at_midnight = night.sun_altitude_deg(_T_MID, SITE)
+        assert sun_alt_at_sunset > sun_alt_at_midnight  # sanity: sunset is brighter
+        constraints = Constraints(max_sun_alt=(sun_alt_at_sunset + sun_alt_at_midnight) / 2)
+        result = observability.check_visibility(
+            ra_deg=evening_transit_ra, dec_deg=ZENITH_DEC, constraints=constraints,
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is False
+        assert result.reason == observability.REASON_SUN_TOO_HIGH
+        assert result.check_time == NIGHT_START
+        assert result.sun_altitude_deg == pytest.approx(sun_alt_at_sunset, abs=0.01)
+
+    def test_morning_target_sun_check_runs_at_sunrise_not_midnight(self):
+        # Mirror of the sunset case: this target is only up at sunrise, so
+        # the sun/moon check (stage 4) must use sunrise, not midnight.
+        morning_transit_ra = 82.4
+        sun_alt_at_sunrise = night.sun_altitude_deg(NIGHT_END, SITE)
+        sun_alt_at_midnight = night.sun_altitude_deg(_T_MID, SITE)
+        assert sun_alt_at_sunrise > sun_alt_at_midnight  # sanity: sunrise is brighter
+        constraints = Constraints(max_sun_alt=(sun_alt_at_sunrise + sun_alt_at_midnight) / 2)
+        result = observability.check_visibility(
+            ra_deg=morning_transit_ra, dec_deg=ZENITH_DEC, constraints=constraints,
+            location=SITE, night_start=NIGHT_START, night_end=NIGHT_END,
+        )
+        assert result.visible is False
+        assert result.reason == observability.REASON_SUN_TOO_HIGH
+        assert result.check_time == NIGHT_END
+        assert result.sun_altitude_deg == pytest.approx(sun_alt_at_sunrise, abs=0.01)


### PR DESCRIPTION
Extract get_night_times, moon_rise_set, transit_altitude_deg, and
ha_window_visible out of hevelius/asteroid.py into hevelius/night.py
(pure refactor, no behavior change for asteroid visibility), and add
sun_altitude_deg, moon_separation_deg, and moon_illumination_pct
alongside them.

Add hevelius/observability.py: a generic (ra_deg, dec_deg, constraints)
staged visibility pipeline - transit-altitude check, night hour-angle
overlap, a representative-moment sun/moon check, then a precise AltAz
confirm - mirroring the cheap-filters-first structure `hevelius asteroid
visible` already uses. This is the engine Night Plan (OS-4, #46) will
call for both tasks and projects; SQL pre-filtering stays the caller's
job since it's table-specific. Includes ra_hours_to_deg with a dedicated
unit test guarding the hours->degrees boundary conversion tasks.ra and
projects.ra need.

Fixed a real astropy pitfall found while testing moon_separation_deg:
comparing a distance-less ICRS SkyCoord directly against a finite-
distance GCRS body via .separation() produced wildly wrong separations
(tens of degrees) with this astropy version. Both positions are now
transformed into the same AltAz frame before comparing.