### PR TITLE
Projects API: report is_complete and subframes_remaining (OS-6, #114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project versioning adheres to [Semantic Versioning](https://semver.org/
   list. Moved out of
   `hevelius/api/routes/tasks.py` into `hevelius/api/routes/night_plan.py`,
   with the planning logic itself in `hevelius/night_plan.py`.
+- Every project the API returns (`GET /api/projects`, `GET /api/projects/{id}`,
+  the create/update responses and the night plan's project items) now carries
+  computed `is_complete` and `subframes_remaining` fields (OS-6, #114), so the
+  Observation Planning UI can tell at a glance what is still owed instead of
+  re-deriving it from `count`/`goal_count` per subframe. No schema change and
+  no new endpoint. Both fields cover the *active* subframes only; a subframe
+  with no `goal_count` is open-ended, so it keeps a project incomplete while
+  adding 0 to the count. The definition of "complete" now lives in one place,
+  `hevelius/projects.py`, which the night plan's `already_complete` test also
+  uses - a project the API calls complete is exactly one the night plan skips.
 - Added `hevelius night-plan show --scope ID [--date YYYY-MM-DD] [--user-id ID]
   [--strategy priority|setting_first] [--explain]`, the CLI twin of the endpoint above - the quickest way to answer
   "why isn't my target in tonight's plan" without going through the web UI.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -729,6 +729,20 @@ components:
           items:
             type: integer
           description: User IDs associated with the project
+        is_complete:
+          type: boolean
+          description: >
+            Computed, not stored: no active subframe has anything left to shoot. A subframe
+            without a goal_count is open-ended and never complete; a project with no subframes
+            at all counts as complete. In a night plan item this describes only the subframes
+            returned there (pending ones this telescope can shoot).
+        subframes_remaining:
+          type: integer
+          description: >
+            Computed, not stored: frames still to capture, summed over the active subframes
+            (goal_count - count). Subframes without a goal_count add 0, so read this together
+            with is_complete rather than instead of it. In a night plan item this counts only
+            the subframes returned there.
     ProjectCreate:
       type: object
       required:

--- a/hevelius/api/routes/projects.py
+++ b/hevelius/api/routes/projects.py
@@ -10,6 +10,7 @@ from flask_smorest import abort
 
 
 from hevelius import db
+from hevelius import projects as projects_lib
 from hevelius.equipment import find_similar_project_names
 from hevelius.api.auth_utils import (
     jwt_user_id_int,
@@ -84,7 +85,11 @@ def _normalize_publications(val):
 
 
 def _project_row_to_dict(r, subframes=None, user_ids=None):
-    """Build project dict from a projects SELECT row (includes last_updated, total_integration_time, dates)."""
+    """Build project dict from a projects SELECT row (includes last_updated, total_integration_time, dates).
+
+    is_complete/subframes_remaining are computed from the subframes as returned here
+    (see hevelius.projects), so the numbers always agree with the counts alongside them.
+    """
     return {
         "project_id": r[0], "name": r[1], "description": r[2], "regexps": r[3], "scope_id": r[4], "ra": r[5], "decl": r[6], "active": r[7],
         "last_updated": r[8], "total_integration_time": float(r[9]) if r[9] is not None else 0.0,
@@ -95,7 +100,8 @@ def _project_row_to_dict(r, subframes=None, user_ids=None):
         "focal": r[14], "resx": r[15], "resy": r[16], "pixel_x": r[17], "pixel_y": r[18],
         "min_alt": r[19], "moon_distance": r[20], "max_moon_phase": r[21], "max_sun_alt": r[22],
         "min_interval": r[23], "priority": r[24],
-        "subframes": subframes or [], "user_ids": user_ids or []
+        "subframes": subframes or [], "user_ids": user_ids or [],
+        **projects_lib.completion(subframes),
     }
 
 

--- a/hevelius/api/schemas/__init__.py
+++ b/hevelius/api/schemas/__init__.py
@@ -569,6 +569,16 @@ class ProjectSchema(Schema):
     priority = fields.Integer(metadata={"description": "Ordering signal for Night Plan / Observation Planning (higher first)"})
     subframes = fields.List(fields.Nested(ProjectSubframeSchema))
     user_ids = fields.List(fields.Integer())
+    is_complete = fields.Boolean(
+        metadata={"description": "Computed: no active subframe has anything left to shoot. A subframe without a "
+                                 "goal_count is open-ended and never complete; a project with no subframes at all "
+                                 "counts as complete"}
+    )
+    subframes_remaining = fields.Integer(
+        metadata={"description": "Computed: frames still to capture, summed over the active subframes "
+                                 "(goal_count - count). Subframes without a goal_count add 0 - read this "
+                                 "together with is_complete, not instead of it"}
+    )
 
 
 class ProjectCreateSchema(Schema):
@@ -690,7 +700,8 @@ class NightPlanItemSchema(Schema):
     task = fields.Nested(Task, allow_none=True, metadata={"description": "The task, when kind is 'task'"})
     project = fields.Nested(
         ProjectSchema, allow_none=True,
-        metadata={"description": "The project, when kind is 'project'; subframes are limited to pending ones this telescope can shoot"}
+        metadata={"description": "The project, when kind is 'project'; subframes are limited to pending ones this "
+                                 "telescope can shoot, and subframes_remaining counts only those"}
     )
     visibility = fields.Nested(NightPlanVisibilitySchema, metadata={"description": "Computed visibility metadata"})
 

--- a/hevelius/night_plan.py
+++ b/hevelius/night_plan.py
@@ -34,6 +34,7 @@ from astropy.time import Time
 from astropy import units as u
 
 from hevelius import db, night, observability
+from hevelius import projects as projects_lib
 from hevelius.observability import Constraints
 
 logger = logging.getLogger(__name__)
@@ -359,21 +360,6 @@ def _project_row_to_dict(row):
     }
 
 
-def _subframe_pending(subframe) -> bool:
-    """
-    Is there anything left to shoot for this subframe?
-
-    Inactive subframes never count. A NULL goal_count means "no target set",
-    which is treated as open-ended rather than complete - a project nobody has
-    given a goal to is still something the telescope can work on.
-    """
-    if not subframe["active"]:
-        return False
-    if subframe["goal_count"] is None:
-        return True
-    return (subframe["count"] or 0) < subframe["goal_count"]
-
-
 def _fetch_subframes(cnx, project_ids):
     """Subframes of the given projects, grouped by project_id."""
     if not project_ids:
@@ -499,11 +485,14 @@ def _collect_projects(cnx, scope: Telescope, night_date: datetime.date,
         project["user_ids"] = users.get(project["project_id"], [])
         reason = _project_exclusion_reason(project, scope, night_date)
         if reason is None:
-            pending = [s for s in subframes.get(project["project_id"], []) if _subframe_pending(s)]
+            pending = [s for s in subframes.get(project["project_id"], []) if projects_lib.subframe_pending(s)]
             on_scope = [s for s in pending if s["filter_id"] in scope_filters]
             reason = _subframe_exclusion_reason(pending, on_scope)
-            # Only the work this telescope can still do is worth returning.
+            # Only the work this telescope can still do is worth returning - and
+            # the completion fields describe exactly those subframes, not the
+            # project's full backlog.
             project["subframes"] = on_scope
+            project.update(projects_lib.completion(on_scope))
 
         if reason is not None:
             if explain:

--- a/hevelius/projects.py
+++ b/hevelius/projects.py
@@ -1,0 +1,54 @@
+"""
+Project completion arithmetic (OS-6, #114).
+
+"How much of this project is still left to shoot" is asked in two places: the
+projects API, which reports it to the Observation Planning UI, and the night
+plan, which drops projects with nothing left to do. Both ask here, so the two
+can never disagree about what "complete" means.
+
+The rules are the ones the night plan has always used:
+
+- an inactive subframe never counts - it is work the user switched off;
+- a NULL `goal_count` means "no target set", which is open-ended rather than
+  complete: a subframe nobody has given a goal to is still something the
+  telescope can work on.
+"""
+
+
+def subframe_pending(subframe) -> bool:
+    """Is there anything left to shoot for this subframe?"""
+    if not subframe.get("active"):
+        return False
+    goal = subframe.get("goal_count")
+    if goal is None:
+        return True
+    return (subframe.get("count") or 0) < goal
+
+
+def subframe_remaining(subframe) -> int:
+    """
+    Frames still to capture for this subframe, 0 when there is nothing left.
+
+    An open-ended subframe (no `goal_count`) contributes 0 even though it is
+    pending: there is work to do, but no number to put on it. That is why the
+    count is meant to be read together with `is_complete`, not instead of it.
+    """
+    goal = subframe.get("goal_count")
+    if goal is None or not subframe.get("active"):
+        return 0
+    return max(0, goal - (subframe.get("count") or 0))
+
+
+def completion(subframes) -> dict:
+    """
+    The computed fields the API adds to every project it returns.
+
+    `is_complete` is the night plan's `already_complete` test: nothing is
+    pending, so the telescope has no reason to point here. A project with no
+    subframes at all is complete by that measure - there is nothing to shoot.
+    """
+    subframes = subframes or []
+    return {
+        "subframes_remaining": sum(subframe_remaining(s) for s in subframes),
+        "is_complete": not any(subframe_pending(s) for s in subframes),
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2259,6 +2259,87 @@ class TestProjectOperations(unittest.TestCase):
         self.assertEqual(data['project']['description'], 'Brand new description')
         os.environ.pop('HEVELIUS_DB_NAME')
 
+    # ── computed completion fields (OS-6) ───────────────────────────────────
+
+    def _create_project(self, name_prefix):
+        """Create a bare project and return its id."""
+        suf = datetime.now().strftime('%H%M%S%f')
+        body = {"name": f"{name_prefix}{suf}", "scope_id": 1, "ra": 0.3, "decl": 12.0}
+        response = self.app.post('/api/projects', data=json.dumps(body), headers=self.headers)
+        self.assertEqual(response.status_code, 201, response.data)
+        return json.loads(response.data)['project_id']
+
+    def _add_subframe(self, project_id, **body):
+        """Add a subframe to a project and return its id."""
+        body.setdefault("filter_id", 1)
+        body.setdefault("exposure_time", 60.0)
+        response = self.app.post(f'/api/projects/{project_id}/subframes',
+                                 data=json.dumps(body), headers=self.headers)
+        self.assertEqual(response.status_code, 201, response.data)
+        return json.loads(response.data)['subframe_id']
+
+    def _get_project(self, project_id):
+        response = self.app.get(f'/api/projects/{project_id}', headers=self.headers)
+        self.assertEqual(response.status_code, 200, response.data)
+        return json.loads(response.data)['project']
+
+    @use_repository
+    def test_project_completion_counts_frames_still_to_shoot(self, config):
+        """is_complete/subframes_remaining track the subframes' progress."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        project_id = self._create_project('Completion')
+
+        # No subframes at all: nothing left to shoot, so complete.
+        project = self._get_project(project_id)
+        self.assertTrue(project['is_complete'])
+        self.assertEqual(project['subframes_remaining'], 0)
+
+        first = self._add_subframe(project_id, count=3, goal_count=10)
+        self._add_subframe(project_id, count=1, goal_count=5)
+        project = self._get_project(project_id)
+        self.assertFalse(project['is_complete'])
+        self.assertEqual(project['subframes_remaining'], 11)
+
+        # Finish the first subframe; only the second one is still owed.
+        response = self.app.patch(f'/api/projects/{project_id}/subframes/{first}',
+                                  data=json.dumps({"count": 10}), headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        project = self._get_project(project_id)
+        self.assertFalse(project['is_complete'])
+        self.assertEqual(project['subframes_remaining'], 4)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_project_completion_ignores_inactive_subframes(self, config):
+        """A subframe switched off is not work the project is waiting on."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        project_id = self._create_project('InactiveSub')
+        self._add_subframe(project_id, count=0, goal_count=20, active=False)
+        self._add_subframe(project_id, count=8, goal_count=8)
+
+        project = self._get_project(project_id)
+        self.assertTrue(project['is_complete'])
+        self.assertEqual(project['subframes_remaining'], 0)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
+    @use_repository
+    def test_projects_list_includes_completion_fields(self, config):
+        """The list response carries the same computed fields as the detail one."""
+        os.environ['HEVELIUS_DB_NAME'] = config['database']
+        project_id = self._create_project('ListCompletion')
+        self._add_subframe(project_id, count=2, goal_count=12)
+
+        listed = json.loads(
+            self.app.get('/api/projects?per_page=1000', headers=self.headers).data
+        )['projects']
+        for project in listed:
+            self.assertIn('is_complete', project)
+            self.assertIn('subframes_remaining', project)
+        ours = next(p for p in listed if p['project_id'] == project_id)
+        self.assertFalse(ours['is_complete'])
+        self.assertEqual(ours['subframes_remaining'], 10)
+        os.environ.pop('HEVELIUS_DB_NAME')
+
     # ── rotation field tests ──────────────────────────────────────────────────
 
     @use_repository

--- a/tests/test_api_night_plan.py
+++ b/tests/test_api_night_plan.py
@@ -394,6 +394,10 @@ class TestNightPlan(unittest.TestCase):
         self.assertEqual(project['subframes'][0]['count'], 3)
         self.assertEqual(project['subframes'][0]['filter']['short_name'], 'NL')
         self.assertEqual(project['user_ids'], [])
+        # The completion fields describe the subframes returned here, i.e. the
+        # pending work this telescope can do: 7 frames of the one NL subframe.
+        self.assertFalse(project['is_complete'])
+        self.assertEqual(project['subframes_remaining'], 7)
 
         reasons = self._reasons(plan)
         self.assertEqual(reasons['NoSubframes'], 'already_complete')

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,73 @@
+"""
+Tests the project completion arithmetic (OS-6, #114).
+
+No DB and no HTTP: hevelius.projects is pure arithmetic over subframe dicts.
+The API-level checks that these numbers actually reach the responses live in
+tests/test_api.py and tests/test_api_night_plan.py.
+"""
+
+import pytest
+
+from hevelius.projects import completion, subframe_pending, subframe_remaining
+
+
+def sub(count=0, goal_count=10, active=True):
+    """A subframe dict shaped like the ones the API and the night plan build."""
+    return {"count": count, "goal_count": goal_count, "active": active}
+
+
+@pytest.mark.parametrize('subframe, pending', [
+    (sub(count=0, goal_count=10), True),
+    (sub(count=9, goal_count=10), True),
+    (sub(count=10, goal_count=10), False),
+    (sub(count=12, goal_count=10), False),          # overshot: still nothing left
+    (sub(count=0, goal_count=0), False),            # goal of zero is met on arrival
+    (sub(count=None, goal_count=10), True),         # no frames captured yet
+    (sub(count=0, goal_count=None), True),          # open-ended: no goal set
+    (sub(count=99, goal_count=None), True),         # open-ended stays open
+    (sub(count=0, goal_count=10, active=False), False),   # switched off
+    (sub(count=0, goal_count=None, active=False), False),
+])
+def test_subframe_pending(subframe, pending):
+    """A subframe is pending unless it is inactive or has met its goal."""
+    assert subframe_pending(subframe) is pending
+
+
+@pytest.mark.parametrize('subframe, remaining', [
+    (sub(count=0, goal_count=10), 10),
+    (sub(count=3, goal_count=10), 7),
+    (sub(count=10, goal_count=10), 0),
+    (sub(count=12, goal_count=10), 0),              # overshoot never goes negative
+    (sub(count=None, goal_count=10), 10),
+    (sub(count=0, goal_count=None), 0),             # pending, but no number to report
+    (sub(count=0, goal_count=10, active=False), 0),
+])
+def test_subframe_remaining(subframe, remaining):
+    """Remaining counts the frames still owed, clamped at zero."""
+    assert subframe_remaining(subframe) == remaining
+
+
+def test_completion_sums_over_subframes():
+    """The project total is the sum of what its subframes still owe."""
+    assert completion([sub(count=3, goal_count=10), sub(count=1, goal_count=5)]) == {
+        "subframes_remaining": 11, "is_complete": False}
+
+
+def test_completion_ignores_inactive_and_finished_subframes():
+    """Only active, unfinished subframes contribute - and keep the project incomplete."""
+    assert completion([
+        sub(count=10, goal_count=10),
+        sub(count=0, goal_count=20, active=False),
+    ]) == {"subframes_remaining": 0, "is_complete": True}
+
+
+def test_completion_of_open_ended_subframe_is_incomplete_but_uncounted():
+    """No goal_count means work with no number on it: incomplete, remaining 0."""
+    assert completion([sub(count=42, goal_count=None)]) == {
+        "subframes_remaining": 0, "is_complete": False}
+
+
+@pytest.mark.parametrize('subframes', [[], None])
+def test_completion_without_subframes_is_complete(subframes):
+    """A project with nothing to shoot is complete - the night plan's own test."""
+    assert completion(subframes) == {"subframes_remaining": 0, "is_complete": True}


### PR DESCRIPTION
The Observation Planning UI wants to show, per project, whether there is
anything left to shoot. It could derive that from the subframes it already
receives, but then every client would carry its own version of the rule -
and the night plan already has one, in _subframe_pending: inactive
subframes don't count, and a NULL goal_count is open-ended rather than
complete.

So the rule moves to hevelius/projects.py and both callers use it. Every
project the API returns - list, detail, create, update, and the night
plan's project items - now carries is_complete and subframes_remaining,
computed from exactly the subframes returned alongside them, so the numbers
can't disagree with the counts next to them. No schema change, no new
endpoint.

subframes_remaining sums goal_count - count over the active subframes and
clamps at zero. An open-ended subframe adds 0 while still keeping
is_complete false: there is work to do, but no number to put on it. Read
the two together, not one instead of the other.

The priority half of the issue (task-add / task-update / GET /api/tasks
sort options, ProjectCreate/UpdateSchema) already landed with OS-2 in #115.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XWPKuNfj3eQ2ngDoR1CPj8